### PR TITLE
Reading State Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@
 ### Reading Experience
 #### Reading State Domain
 - [x] создать `ArticleStateService` как единый orchestration-слой поверх `ArticleStateRepository`;
-- [ ] реализовать `markAsRead`;
+- [x] реализовать `markAsRead`;
 - [ ] реализовать `markAsUnread`;
 - [ ] реализовать `toggleStarred`;
 - [ ] реализовать bulk action `markAllVisibleAsRead`;

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@
 #### Reading State Domain
 - [x] создать `ArticleStateService` как единый orchestration-слой поверх `ArticleStateRepository`;
 - [x] реализовать `markAsRead`;
-- [ ] реализовать `markAsUnread`;
+- [x] реализовать `markAsUnread`;
 - [ ] реализовать `toggleStarred`;
 - [ ] реализовать bulk action `markAllVisibleAsRead`;
 - [ ] обновлять `updatedAt` и `lastInteractionAt` при каждом пользовательском изменении;

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@
 - [x] реализовать bulk action `markAllVisibleAsRead`;
 - [x] обновлять `updatedAt` и `lastInteractionAt` при каждом пользовательском изменении;
 - [x] подготовить policy `last-write-wins` для будущих sync-конфликтов по `ArticleState.updatedAt`;
-- [ ] добавить unit tests для article state transitions.
+- [x] добавить unit tests для article state transitions.
 
 #### Reading Shell / Navigation
 - [ ] определить финальную модель selection/navigation для `Sources -> Articles -> Article -> WebView`;

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@
 - [x] создать `ArticleStateService` как единый orchestration-слой поверх `ArticleStateRepository`;
 - [x] реализовать `markAsRead`;
 - [x] реализовать `markAsUnread`;
-- [ ] реализовать `toggleStarred`;
+- [x] реализовать `toggleStarred`;
 - [ ] реализовать bulk action `markAllVisibleAsRead`;
 - [ ] обновлять `updatedAt` и `lastInteractionAt` при каждом пользовательском изменении;
 - [ ] подготовить policy `last-write-wins` для будущих sync-конфликтов по `ArticleState.updatedAt`;

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@
 - [x] реализовать `markAsRead`;
 - [x] реализовать `markAsUnread`;
 - [x] реализовать `toggleStarred`;
-- [ ] реализовать bulk action `markAllVisibleAsRead`;
+- [x] реализовать bulk action `markAllVisibleAsRead`;
 - [ ] обновлять `updatedAt` и `lastInteractionAt` при каждом пользовательском изменении;
 - [ ] подготовить policy `last-write-wins` для будущих sync-конфликтов по `ArticleState.updatedAt`;
 - [ ] добавить unit tests для article state transitions.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@
 - [x] реализовать `markAsUnread`;
 - [x] реализовать `toggleStarred`;
 - [x] реализовать bulk action `markAllVisibleAsRead`;
-- [ ] обновлять `updatedAt` и `lastInteractionAt` при каждом пользовательском изменении;
+- [x] обновлять `updatedAt` и `lastInteractionAt` при каждом пользовательском изменении;
 - [ ] подготовить policy `last-write-wins` для будущих sync-конфликтов по `ArticleState.updatedAt`;
 - [ ] добавить unit tests для article state transitions.
 

--- a/README.md
+++ b/README.md
@@ -155,51 +155,65 @@
 - [x] добавить integration tests на обновление feed metadata и reconciliation статей после refresh.
 
 ### Reading Experience
-#### User State / Reading Actions
-- [ ] создать ArticleStateService;
-- [ ] реализовать markAsRead;
-- [ ] реализовать markAsUnread;
-- [ ] реализовать toggleStarred;
-- [ ] добавить markAsReadOnOpen;
-- [ ] добавить bulk action markAllVisibleAsRead;
-- [ ] обновлять updatedAt при каждом пользовательском изменении;
-- [ ] подготовить логику last-write-wins для конфликтов состояния.
+#### Reading State Domain
+- [x] создать `ArticleStateService` как единый orchestration-слой поверх `ArticleStateRepository`;
+- [ ] реализовать `markAsRead`;
+- [ ] реализовать `markAsUnread`;
+- [ ] реализовать `toggleStarred`;
+- [ ] реализовать bulk action `markAllVisibleAsRead`;
+- [ ] обновлять `updatedAt` и `lastInteractionAt` при каждом пользовательском изменении;
+- [ ] подготовить policy `last-write-wins` для будущих sync-конфликтов по `ArticleState.updatedAt`;
+- [ ] добавить unit tests для article state transitions.
 
-#### Sidebar UI
-- [ ] создать SidebarViewModel;
-- [ ] экран sidebar со списком feeds;
-- [ ] показ unread counts;
+#### Reading Shell / Navigation
+- [ ] определить финальную модель selection/navigation для `Sources -> Articles -> Article -> WebView`;
+- [ ] стабилизировать selection при refresh и смене фильтра;
+- [ ] добавить refresh/selection behavior для смены source без рассинхронизации списка и reader;
+- [ ] подготовить entry points для menu / source actions, которые нужны shell-уровню.
+
+#### Sources Screen
+- [ ] привести текущий sidebar к дизайну экрана Sources;
 - [ ] добавить smart sections: All;
 - [ ] добавить smart sections: Unread;
 - [ ] добавить smart sections: Starred;
-- [ ] добавить выбор активного feed;
-- [ ] добавить empty state для отсутствия подписок.
+- [ ] показать loading/error state, а не только empty state.
 
-#### Article List UI
-- [ ] создать ArticleListViewModel;
-- [ ] список статей выбранного feed;
-- [ ] глобальный список всех статей;
-- [ ] сортировка по publishedAt desc;
-- [ ] фильтр unread only;
-- [ ] отображение состояния read/unread;
-- [ ] отображение starred state;
-- [ ] pull to refresh (c async/await обработкой обновления);
-- [ ] empty state для пустого списка;
-- [ ] error state для ошибки загрузки.
+#### Articles Screen
+- [ ] привести текущий список к дизайну экрана Articles;
+- [ ] добавить фильтры `All / Unread / Starred` поверх существующего query-layer;
+- [ ] применить `AppSettings.showUnreadOnly` как initial/default behavior;
+- [ ] визуально показать `read/unread` и `starred` state в ячейке;
+- [ ] показать metadata row: source / date / secondary text;
+- [ ] добавить `pull to refresh` для текущего selection через `FeedRefreshService`;
+- [ ] добавить полноценный loading/error UX для загрузки и refresh.
 
-#### Reader UI
-- [ ] создать ReaderViewModel;
-- [ ] экран чтения статьи;
-- [ ] показ title/source/date;
-- [ ] показ summary/content;
-- [ ] действие open in browser;
-- [ ] действие share;
-- [ ] действие mark unread;
-- [ ] действие star/unstar;
-- [ ] автоматическая отметка read on appear.
+#### Article Screen
+- [ ] привести текущий reader к дизайну экрана Article;
+- [ ] оформить header: title / source / date / author;
+- [ ] улучшить rendering summary/content/plain text;
+- [ ] добавить actions: `mark unread`, `star/unstar`, `share`, `open in browser`;
+- [ ] реализовать `markAsReadOnOpen` на основе `AppSettings`;
+- [ ] связать экран со state actions из `ArticleStateService`.
 
-#### Add Feed Flow
-- [ ] создать AddFeedViewModel;
+#### WebView Screen
+- [ ] создать отдельный экран WebView для `articleURL`;
+- [ ] поддержать `defaultReaderMode` из `AppSettings`;
+- [ ] добавить loading state для web content;
+- [ ] добавить error/fallback UX, если `articleURL` не открывается;
+- [ ] добавить action открытия во внешнем браузере.
+
+#### Settings Integration
+- [ ] создать `SettingsViewModel`;
+- [ ] экран настроек;
+- [ ] настройка `markAsReadOnOpen`;
+- [ ] настройка `showUnreadOnly`;
+- [ ] настройка `sortMode`;
+- [ ] настройка `defaultReaderMode`;
+- [ ] iCloud sync indicator;
+- [ ] ручной refresh.
+
+#### Source Management
+- [ ] создать `AddFeedViewModel`;
 - [ ] экран добавления feed по URL;
 - [ ] валидация URL;
 - [ ] превью найденного feed;
@@ -207,15 +221,6 @@
 - [ ] первый refresh после добавления;
 - [ ] обработка ошибки при невалидном или неподдерживаемом feed;
 - [ ] empty/error UX для add feed flow.
-
-#### Settings
-- [ ] создать SettingsViewModel;
-- [ ] экран настроек;
-- [ ] markAsReadOnOpen;
-- [ ] show unread only default;
-- [ ] sort mode;
-- [ ] iCloud sync indicator;
-- [ ] ручной refresh.
 
 ### Sync
 #### Sync / CloudKit

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@
 - [x] реализовать `toggleStarred`;
 - [x] реализовать bulk action `markAllVisibleAsRead`;
 - [x] обновлять `updatedAt` и `lastInteractionAt` при каждом пользовательском изменении;
-- [ ] подготовить policy `last-write-wins` для будущих sync-конфликтов по `ArticleState.updatedAt`;
+- [x] подготовить policy `last-write-wins` для будущих sync-конфликтов по `ArticleState.updatedAt`;
 - [ ] добавить unit tests для article state transitions.
 
 #### Reading Shell / Navigation

--- a/RSSReader/Infrastructure/AppDependencies.swift
+++ b/RSSReader/Infrastructure/AppDependencies.swift
@@ -18,6 +18,7 @@ public final class AppDependencies: AppDependenciesProtocol {
     let feedRefreshService: FeedRefreshService?
     let feedRepository: (any FeedRepository)?
     let articleRepository: (any ArticleRepository)?
+    let articleStateService: ArticleStateService?
     let articleQueryService: (any ArticleQueryService)?
     let articleStateRepository: (any ArticleStateRepository)?
     let appSettingsRepository: (any AppSettingsRepository)?
@@ -50,6 +51,12 @@ public final class AppDependencies: AppDependenciesProtocol {
                 articleStateRepository: articleStateRepository
             )
         }()
+        let articleStateService = articleStateRepository.map { repository in
+            ArticleStateService(
+                logger: logger,
+                articleStateRepository: repository
+            )
+        }
         let appSettingsRepository = modelContainer.map { container in
             SwiftDataAppSettingsRepository(modelContext: container.mainContext)
         }
@@ -79,6 +86,7 @@ public final class AppDependencies: AppDependenciesProtocol {
         self.feedRefreshService = feedRefreshService
         self.feedRepository = feedRepository
         self.articleRepository = articleRepository
+        self.articleStateService = articleStateService
         self.articleStateRepository = articleStateRepository
         self.articleQueryService = articleQueryService
         self.appSettingsRepository = appSettingsRepository

--- a/RSSReader/Services/Articles/ArticleStateService.swift
+++ b/RSSReader/Services/Articles/ArticleStateService.swift
@@ -11,6 +11,9 @@ protocol ArticleStateServicing {
     func markAsUnread(article: Article, at: Date) throws -> ArticleUserStateSnapshot
     func toggleStarred(feedID: UUID, articleExternalID: String, at: Date) throws -> ArticleUserStateSnapshot
     func toggleStarred(article: Article, at: Date) throws -> ArticleUserStateSnapshot
+    func markAllVisibleAsRead(feedID: UUID, articleExternalIDs: [String], at: Date) throws -> [ArticleUserStateSnapshot]
+    func markAllVisibleAsRead(_ items: [ArticleListItemDTO], at: Date) throws -> [ArticleUserStateSnapshot]
+    func markAllVisibleAsRead(_ articles: [Article], at: Date) throws -> [ArticleUserStateSnapshot]
 }
 
 @MainActor
@@ -133,5 +136,62 @@ final class ArticleStateService: ArticleStateServicing {
             articleExternalID: article.externalID,
             at: at
         )
+    }
+
+    func markAllVisibleAsRead(
+        feedID: UUID,
+        articleExternalIDs: [String],
+        at: Date = .now
+    ) throws -> [ArticleUserStateSnapshot] {
+        guard articleExternalIDs.isEmpty == false else { return [] }
+
+        let articleStates = try articleStateRepository.bulkSetRead(
+            feedID: feedID,
+            articleExternalIDs: articleExternalIDs,
+            isRead: true,
+            at: at
+        )
+        logger.info("Marked \(articleStates.count) visible articles as read for feed \(feedID.uuidString)")
+        return articleStates.map(ArticleUserStateSnapshot.init(articleState:))
+    }
+
+    func markAllVisibleAsRead(
+        _ items: [ArticleListItemDTO],
+        at: Date = .now
+    ) throws -> [ArticleUserStateSnapshot] {
+        guard items.isEmpty == false else { return [] }
+
+        let itemsByFeedID = Dictionary(grouping: items, by: \.feedID)
+        return try itemsByFeedID
+            .keys
+            .sorted { $0.uuidString < $1.uuidString }
+            .flatMap { feedID in
+                let articleExternalIDs = itemsByFeedID[feedID, default: []].map(\.articleExternalID)
+                return try markAllVisibleAsRead(
+                    feedID: feedID,
+                    articleExternalIDs: articleExternalIDs,
+                    at: at
+                )
+            }
+    }
+
+    func markAllVisibleAsRead(
+        _ articles: [Article],
+        at: Date = .now
+    ) throws -> [ArticleUserStateSnapshot] {
+        guard articles.isEmpty == false else { return [] }
+
+        let articlesByFeedID = Dictionary(grouping: articles, by: \.feedID)
+        return try articlesByFeedID
+            .keys
+            .sorted { $0.uuidString < $1.uuidString }
+            .flatMap { feedID in
+                let articleExternalIDs = articlesByFeedID[feedID, default: []].map(\.externalID)
+                return try markAllVisibleAsRead(
+                    feedID: feedID,
+                    articleExternalIDs: articleExternalIDs,
+                    at: at
+                )
+            }
     }
 }

--- a/RSSReader/Services/Articles/ArticleStateService.swift
+++ b/RSSReader/Services/Articles/ArticleStateService.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@MainActor
+protocol ArticleStateServicing {
+    func fetchStateSnapshot(feedID: UUID, articleExternalID: String) throws -> ArticleUserStateSnapshot?
+    func fetchStateSnapshots(for articles: [Article]) throws -> [String: ArticleUserStateSnapshot]
+    func fetchUnreadCounts(feedIDs: [UUID]) throws -> [UUID: Int]
+}
+
+@MainActor
+final class ArticleStateService: ArticleStateServicing {
+    private let logger: Logging
+    private let articleStateRepository: any ArticleStateRepository
+
+    init(
+        logger: Logging,
+        articleStateRepository: any ArticleStateRepository
+    ) {
+        self.logger = logger
+        self.articleStateRepository = articleStateRepository
+    }
+
+    func fetchStateSnapshot(feedID: UUID, articleExternalID: String) throws -> ArticleUserStateSnapshot? {
+        try articleStateRepository.fetchStateSnapshot(
+            feedID: feedID,
+            articleExternalID: articleExternalID
+        )
+    }
+
+    func fetchStateSnapshots(for articles: [Article]) throws -> [String: ArticleUserStateSnapshot] {
+        guard articles.isEmpty == false else { return [:] }
+
+        let snapshots = try articleStateRepository.fetchStateSnapshots(for: articles)
+        logger.debug("Fetched article state snapshots for \(articles.count) articles")
+        return snapshots
+    }
+
+    func fetchUnreadCounts(feedIDs: [UUID]) throws -> [UUID: Int] {
+        guard feedIDs.isEmpty == false else { return [:] }
+
+        let unreadCounts = try articleStateRepository.fetchUnreadCounts(feedIDs: feedIDs)
+        logger.debug("Fetched unread counts for \(feedIDs.count) feeds")
+        return unreadCounts
+    }
+}

--- a/RSSReader/Services/Articles/ArticleStateService.swift
+++ b/RSSReader/Services/Articles/ArticleStateService.swift
@@ -7,6 +7,8 @@ protocol ArticleStateServicing {
     func fetchUnreadCounts(feedIDs: [UUID]) throws -> [UUID: Int]
     func markAsRead(feedID: UUID, articleExternalID: String, at: Date) throws -> ArticleUserStateSnapshot
     func markAsRead(article: Article, at: Date) throws -> ArticleUserStateSnapshot
+    func markAsUnread(feedID: UUID, articleExternalID: String, at: Date) throws -> ArticleUserStateSnapshot
+    func markAsUnread(article: Article, at: Date) throws -> ArticleUserStateSnapshot
 }
 
 @MainActor
@@ -66,6 +68,33 @@ final class ArticleStateService: ArticleStateServicing {
 
     func markAsRead(article: Article, at: Date = .now) throws -> ArticleUserStateSnapshot {
         try markAsRead(
+            feedID: article.feedID,
+            articleExternalID: article.externalID,
+            at: at
+        )
+    }
+
+    func markAsUnread(
+        feedID: UUID,
+        articleExternalID: String,
+        at: Date = .now
+    ) throws -> ArticleUserStateSnapshot {
+        let articleState = try articleStateRepository.upsert(
+            feedID: feedID,
+            articleExternalID: articleExternalID,
+            update: ArticleStateUpsert(
+                isRead: false,
+                readAt: nil,
+                lastInteractionAt: at,
+                updatedAt: at
+            )
+        )
+        logger.info("Marked article as unread for feed \(feedID.uuidString)")
+        return ArticleUserStateSnapshot(articleState: articleState)
+    }
+
+    func markAsUnread(article: Article, at: Date = .now) throws -> ArticleUserStateSnapshot {
+        try markAsUnread(
             feedID: article.feedID,
             articleExternalID: article.externalID,
             at: at

--- a/RSSReader/Services/Articles/ArticleStateService.swift
+++ b/RSSReader/Services/Articles/ArticleStateService.swift
@@ -5,6 +5,8 @@ protocol ArticleStateServicing {
     func fetchStateSnapshot(feedID: UUID, articleExternalID: String) throws -> ArticleUserStateSnapshot?
     func fetchStateSnapshots(for articles: [Article]) throws -> [String: ArticleUserStateSnapshot]
     func fetchUnreadCounts(feedIDs: [UUID]) throws -> [UUID: Int]
+    func markAsRead(feedID: UUID, articleExternalID: String, at: Date) throws -> ArticleUserStateSnapshot
+    func markAsRead(article: Article, at: Date) throws -> ArticleUserStateSnapshot
 }
 
 @MainActor
@@ -41,5 +43,32 @@ final class ArticleStateService: ArticleStateServicing {
         let unreadCounts = try articleStateRepository.fetchUnreadCounts(feedIDs: feedIDs)
         logger.debug("Fetched unread counts for \(feedIDs.count) feeds")
         return unreadCounts
+    }
+
+    func markAsRead(
+        feedID: UUID,
+        articleExternalID: String,
+        at: Date = .now
+    ) throws -> ArticleUserStateSnapshot {
+        let articleState = try articleStateRepository.upsert(
+            feedID: feedID,
+            articleExternalID: articleExternalID,
+            update: ArticleStateUpsert(
+                isRead: true,
+                readAt: at,
+                lastInteractionAt: at,
+                updatedAt: at
+            )
+        )
+        logger.info("Marked article as read for feed \(feedID.uuidString)")
+        return ArticleUserStateSnapshot(articleState: articleState)
+    }
+
+    func markAsRead(article: Article, at: Date = .now) throws -> ArticleUserStateSnapshot {
+        try markAsRead(
+            feedID: article.feedID,
+            articleExternalID: article.externalID,
+            at: at
+        )
     }
 }

--- a/RSSReader/Services/Articles/ArticleStateService.swift
+++ b/RSSReader/Services/Articles/ArticleStateService.swift
@@ -60,12 +60,7 @@ final class ArticleStateService: ArticleStateServicing {
         let articleState = try articleStateRepository.upsert(
             feedID: feedID,
             articleExternalID: articleExternalID,
-            update: ArticleStateUpsert(
-                isRead: true,
-                readAt: at,
-                lastInteractionAt: at,
-                updatedAt: at
-            )
+            update: makeReadUpdate(isRead: true, at: at)
         )
         logger.info("Marked article as read for feed \(feedID.uuidString)")
         return ArticleUserStateSnapshot(articleState: articleState)
@@ -87,12 +82,7 @@ final class ArticleStateService: ArticleStateServicing {
         let articleState = try articleStateRepository.upsert(
             feedID: feedID,
             articleExternalID: articleExternalID,
-            update: ArticleStateUpsert(
-                isRead: false,
-                readAt: nil,
-                lastInteractionAt: at,
-                updatedAt: at
-            )
+            update: makeReadUpdate(isRead: false, at: at)
         )
         logger.info("Marked article as unread for feed \(feedID.uuidString)")
         return ArticleUserStateSnapshot(articleState: articleState)
@@ -119,12 +109,7 @@ final class ArticleStateService: ArticleStateServicing {
         let articleState = try articleStateRepository.upsert(
             feedID: feedID,
             articleExternalID: articleExternalID,
-            update: ArticleStateUpsert(
-                isStarred: newIsStarred,
-                starredAt: newIsStarred ? at : nil,
-                lastInteractionAt: at,
-                updatedAt: at
-            )
+            update: makeStarredUpdate(isStarred: newIsStarred, at: at)
         )
         logger.info("Toggled starred state for article in feed \(feedID.uuidString)")
         return ArticleUserStateSnapshot(articleState: articleState)
@@ -193,5 +178,23 @@ final class ArticleStateService: ArticleStateServicing {
                     at: at
                 )
             }
+    }
+
+    private func makeReadUpdate(isRead: Bool, at: Date) -> ArticleStateUpsert {
+        ArticleStateUpsert(
+            isRead: isRead,
+            readAt: isRead ? at : nil,
+            lastInteractionAt: at,
+            updatedAt: at
+        )
+    }
+
+    private func makeStarredUpdate(isStarred: Bool, at: Date) -> ArticleStateUpsert {
+        ArticleStateUpsert(
+            isStarred: isStarred,
+            starredAt: isStarred ? at : nil,
+            lastInteractionAt: at,
+            updatedAt: at
+        )
     }
 }

--- a/RSSReader/Services/Articles/ArticleStateService.swift
+++ b/RSSReader/Services/Articles/ArticleStateService.swift
@@ -9,6 +9,8 @@ protocol ArticleStateServicing {
     func markAsRead(article: Article, at: Date) throws -> ArticleUserStateSnapshot
     func markAsUnread(feedID: UUID, articleExternalID: String, at: Date) throws -> ArticleUserStateSnapshot
     func markAsUnread(article: Article, at: Date) throws -> ArticleUserStateSnapshot
+    func toggleStarred(feedID: UUID, articleExternalID: String, at: Date) throws -> ArticleUserStateSnapshot
+    func toggleStarred(article: Article, at: Date) throws -> ArticleUserStateSnapshot
 }
 
 @MainActor
@@ -95,6 +97,38 @@ final class ArticleStateService: ArticleStateServicing {
 
     func markAsUnread(article: Article, at: Date = .now) throws -> ArticleUserStateSnapshot {
         try markAsUnread(
+            feedID: article.feedID,
+            articleExternalID: article.externalID,
+            at: at
+        )
+    }
+
+    func toggleStarred(
+        feedID: UUID,
+        articleExternalID: String,
+        at: Date = .now
+    ) throws -> ArticleUserStateSnapshot {
+        let currentState = try articleStateRepository.fetchStateSnapshot(
+            feedID: feedID,
+            articleExternalID: articleExternalID
+        )
+        let newIsStarred = (currentState?.isStarred ?? false) == false
+        let articleState = try articleStateRepository.upsert(
+            feedID: feedID,
+            articleExternalID: articleExternalID,
+            update: ArticleStateUpsert(
+                isStarred: newIsStarred,
+                starredAt: newIsStarred ? at : nil,
+                lastInteractionAt: at,
+                updatedAt: at
+            )
+        )
+        logger.info("Toggled starred state for article in feed \(feedID.uuidString)")
+        return ArticleUserStateSnapshot(articleState: articleState)
+    }
+
+    func toggleStarred(article: Article, at: Date = .now) throws -> ArticleUserStateSnapshot {
+        try toggleStarred(
             feedID: article.feedID,
             articleExternalID: article.externalID,
             at: at

--- a/RSSReader/Services/Repositories/ArticleStateRepository.swift
+++ b/RSSReader/Services/Repositories/ArticleStateRepository.swift
@@ -38,6 +38,10 @@ struct ArticleStateUpsert: Sendable {
     var updatedAt: Date = .now
 }
 
+enum ArticleStateConflictResolutionPolicy: Sendable {
+    case lastWriteWinsByUpdatedAt
+}
+
 @MainActor
 protocol ArticleStateRepository {
     func fetchState(feedID: UUID, articleExternalID: String) throws -> ArticleState?
@@ -65,9 +69,14 @@ protocol ArticleStateRepository {
 @MainActor
 final class SwiftDataArticleStateRepository: ArticleStateRepository, SwiftDataRepositoryContext {
     let modelContext: ModelContext
+    private let conflictResolutionPolicy: ArticleStateConflictResolutionPolicy
 
-    init(modelContext: ModelContext) {
+    init(
+        modelContext: ModelContext,
+        conflictResolutionPolicy: ArticleStateConflictResolutionPolicy = .lastWriteWinsByUpdatedAt
+    ) {
         self.modelContext = modelContext
+        self.conflictResolutionPolicy = conflictResolutionPolicy
     }
 
     func fetchState(feedID: UUID, articleExternalID: String) throws -> ArticleState? {
@@ -255,6 +264,8 @@ final class SwiftDataArticleStateRepository: ArticleStateRepository, SwiftDataRe
     }
 
     private func apply(_ update: ArticleStateUpsert, to articleState: ArticleState) {
+        guard shouldApply(update, to: articleState) else { return }
+
         var didChange = false
 
         if let isRead = update.isRead, articleState.isRead != isRead {
@@ -293,6 +304,13 @@ final class SwiftDataArticleStateRepository: ArticleStateRepository, SwiftDataRe
 
         if didChange || update.lastInteractionAt != nil {
             articleState.updatedAt = update.updatedAt
+        }
+    }
+
+    private func shouldApply(_ update: ArticleStateUpsert, to articleState: ArticleState) -> Bool {
+        switch conflictResolutionPolicy {
+        case .lastWriteWinsByUpdatedAt:
+            return update.updatedAt >= articleState.updatedAt
         }
     }
 }

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -493,7 +493,7 @@ struct RSSReaderTests {
         feed.kind = .unknown
         try harness.saveModelContext()
 
-        try harness.insertArticle(
+        _ = try harness.insertArticle(
             feed: feed,
             externalID: "obsolete-article",
             guid: "obsolete-article",
@@ -559,7 +559,7 @@ struct RSSReaderTests {
                 publishedAt: FeedDateParsingService.parse("Tue, 02 Jan 2024 10:00:00 GMT")
             )
         )
-        try harness.insertArticle(
+        _ = try harness.insertArticle(
             feed: feed,
             externalID: refreshedEntryExternalID,
             guid: "revived-article",
@@ -580,6 +580,156 @@ struct RSSReaderTests {
         #expect(revivedArticle.externalID == refreshedEntryExternalID)
         #expect(revivedArticle.isDeletedAtSource == false)
         #expect(revivedArticle.title == "Revived Article")
+    }
+
+    @Test
+    func articleStateReadUnreadTransitionUpdatesStateAndInteractionTimestamps() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/state-read.xml"]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: "state-read-article",
+            url: "https://example.com/state-read/articles/1",
+            title: "State Read Article"
+        )
+        let baseTime = Date().addingTimeInterval(60)
+        let readAt = baseTime
+        let unreadAt = baseTime.addingTimeInterval(600)
+
+        let readSnapshot = try harness.articleStateService.markAsRead(article: article, at: readAt)
+        let unreadSnapshot = try harness.articleStateService.markAsUnread(article: article, at: unreadAt)
+
+        #expect(readSnapshot.isRead == true)
+        #expect(readSnapshot.readAt == readAt)
+        #expect(readSnapshot.lastInteractionAt == readAt)
+        #expect(readSnapshot.updatedAt == readAt)
+
+        #expect(unreadSnapshot.isRead == false)
+        #expect(unreadSnapshot.readAt == nil)
+        #expect(unreadSnapshot.lastInteractionAt == unreadAt)
+        #expect(unreadSnapshot.updatedAt == unreadAt)
+
+        let persistedSnapshot = try harness.articleStateService.fetchStateSnapshot(
+            feedID: feed.id,
+            articleExternalID: article.externalID
+        )
+        let state = try #require(persistedSnapshot)
+        #expect(state.isRead == false)
+        #expect(state.readAt == nil)
+        #expect(state.lastInteractionAt == unreadAt)
+        #expect(state.updatedAt == unreadAt)
+    }
+
+    @Test
+    func articleStateToggleStarredTransitionsOnAndOffWithFreshTimestamps() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/state-star.xml"]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: "state-star-article",
+            url: "https://example.com/state-star/articles/1",
+            title: "State Star Article"
+        )
+        let baseTime = Date().addingTimeInterval(60)
+        let starredAt = baseTime
+        let unstarredAt = baseTime.addingTimeInterval(300)
+
+        let starredSnapshot = try harness.articleStateService.toggleStarred(article: article, at: starredAt)
+        let unstarredSnapshot = try harness.articleStateService.toggleStarred(article: article, at: unstarredAt)
+
+        #expect(starredSnapshot.isStarred == true)
+        #expect(starredSnapshot.starredAt == starredAt)
+        #expect(starredSnapshot.lastInteractionAt == starredAt)
+        #expect(starredSnapshot.updatedAt == starredAt)
+
+        #expect(unstarredSnapshot.isStarred == false)
+        #expect(unstarredSnapshot.starredAt == nil)
+        #expect(unstarredSnapshot.lastInteractionAt == unstarredAt)
+        #expect(unstarredSnapshot.updatedAt == unstarredAt)
+    }
+
+    @Test
+    func articleStateBulkMarkAllVisibleAsReadMarksArticlesAcrossFeeds() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feeds = try harness.insertFeeds(
+            urls: [
+                "https://example.com/state-bulk-1.xml",
+                "https://example.com/state-bulk-2.xml"
+            ]
+        )
+        let firstArticle = try harness.insertArticle(
+            feed: feeds[0],
+            externalID: "bulk-article-1",
+            url: "https://example.com/state-bulk-1/articles/1",
+            title: "Bulk Article One"
+        )
+        let secondArticle = try harness.insertArticle(
+            feed: feeds[0],
+            externalID: "bulk-article-2",
+            url: "https://example.com/state-bulk-1/articles/2",
+            title: "Bulk Article Two"
+        )
+        let thirdArticle = try harness.insertArticle(
+            feed: feeds[1],
+            externalID: "bulk-article-3",
+            url: "https://example.com/state-bulk-2/articles/1",
+            title: "Bulk Article Three"
+        )
+        let actionAt = Date().addingTimeInterval(60)
+
+        let snapshots = try harness.articleStateService.markAllVisibleAsRead(
+            [firstArticle, secondArticle, thirdArticle],
+            at: actionAt
+        )
+
+        #expect(snapshots.count == 3)
+        #expect(snapshots.allSatisfy { $0.isRead })
+        #expect(snapshots.allSatisfy { $0.readAt == actionAt })
+        #expect(snapshots.allSatisfy { $0.lastInteractionAt == actionAt })
+        #expect(snapshots.allSatisfy { $0.updatedAt == actionAt })
+
+        let persistedSnapshots = try harness.articleStateService.fetchStateSnapshots(
+            for: [firstArticle, secondArticle, thirdArticle]
+        )
+        #expect(persistedSnapshots.count == 3)
+        #expect(Array(persistedSnapshots.values).allSatisfy { $0.isRead })
+        #expect(persistedSnapshots.values.allSatisfy { $0.readAt == actionAt })
+    }
+
+    @Test
+    func articleStateRejectsStaleTransitionWhenUpdatedAtIsOlderThanCurrentState() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/state-lww.xml"]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: "state-lww-article",
+            url: "https://example.com/state-lww/articles/1",
+            title: "State LWW Article"
+        )
+        let newerTimestamp = Date().addingTimeInterval(120)
+        let olderTimestamp = Date().addingTimeInterval(60)
+
+        _ = try harness.articleStateService.markAsRead(article: article, at: newerTimestamp)
+        _ = try harness.articleStateRepository.upsert(
+            feedID: feed.id,
+            articleExternalID: article.externalID,
+            update: ArticleStateUpsert(
+                isRead: false,
+                readAt: nil,
+                lastInteractionAt: olderTimestamp,
+                updatedAt: olderTimestamp
+            )
+        )
+
+        let persistedSnapshot = try harness.articleStateService.fetchStateSnapshot(
+            feedID: feed.id,
+            articleExternalID: article.externalID
+        )
+        let state = try #require(persistedSnapshot)
+        #expect(state.isRead == true)
+        #expect(state.readAt == newerTimestamp)
+        #expect(state.lastInteractionAt == newerTimestamp)
+        #expect(state.updatedAt == newerTimestamp)
     }
 }
 
@@ -619,6 +769,8 @@ private struct TestHarness {
     let modelContainer: ModelContainer
     let feedRepository: SwiftDataFeedRepository
     let articleRepository: SwiftDataArticleRepository
+    let articleStateRepository: SwiftDataArticleStateRepository
+    let articleStateService: ArticleStateService
     let feedFetchLogRepository: SwiftDataFeedFetchLogRepository
     let service: FeedRefreshService
     let httpClient: ScriptedHTTPClient
@@ -639,6 +791,11 @@ private struct TestHarness {
 
         let feedRepository = SwiftDataFeedRepository(modelContext: modelContext)
         let articleRepository = SwiftDataArticleRepository(modelContext: modelContext)
+        let articleStateRepository = SwiftDataArticleStateRepository(modelContext: modelContext)
+        let articleStateService = ArticleStateService(
+            logger: TestLogger(),
+            articleStateRepository: articleStateRepository
+        )
         let feedFetchLogRepository = SwiftDataFeedFetchLogRepository(modelContext: modelContext)
         let service = FeedRefreshService(
             logger: TestLogger(),
@@ -655,6 +812,8 @@ private struct TestHarness {
             modelContainer: modelContainer,
             feedRepository: feedRepository,
             articleRepository: articleRepository,
+            articleStateRepository: articleStateRepository,
+            articleStateService: articleStateService,
             feedFetchLogRepository: feedFetchLogRepository,
             service: service,
             httpClient: httpClient
@@ -688,7 +847,7 @@ private struct TestHarness {
         url: String,
         title: String,
         isDeletedAtSource: Bool = false
-    ) throws {
+    ) throws -> Article {
         let article = Article(
             feed: feed,
             externalID: externalID,
@@ -699,6 +858,7 @@ private struct TestHarness {
         )
         modelContainer.mainContext.insert(article)
         try modelContainer.mainContext.save()
+        return article
     }
 
     @MainActor


### PR DESCRIPTION
## Кратко
Задача Reading State Domain выполнена

Реализовано:
- [x] создать `ArticleStateService` как единый orchestration-слой поверх `ArticleStateRepository`;
- [x] реализовать `markAsRead`;
- [x] реализовать `markAsUnread`;
- [x] реализовать `toggleStarred`;
- [x] реализовать bulk action `markAllVisibleAsRead`;
- [x] обновлять `updatedAt` и `lastInteractionAt` при каждом пользовательском изменении;
- [x] подготовить policy `last-write-wins` для будущих sync-конфликтов по `ArticleState.updatedAt`;
- [x] добавить unit tests для article state transitions.

## Закрывает
Closes #87 
Closes #88 
Closes #89 
Closes #90 
Closes #91 
Closes #92 
Closes #93 
Closes #94 
Closes #86 