### PR TITLE
Reading Shell / Navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@
 - [x] добавить unit tests на source switch: сброс article/detail selection и reload trigger;
 - [x] добавить unit tests на filter switch: обновление active filter без потери shell consistency;
 - [x] добавить unit tests на web view route: open/close article web view через `AppState`;
-- [ ] добавить unit tests на shell action entry points в `AppDependencies`.
+- [x] добавить unit tests на shell action entry points в `AppDependencies`.
 
 #### Sources Screen
 - [ ] привести текущий sidebar к дизайну экрана Sources;

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@
 - [x] подготовить entry points для menu / source actions, которые нужны shell-уровню.
 - [x] добавить unit tests на source switch: сброс article/detail selection и reload trigger;
 - [x] добавить unit tests на filter switch: обновление active filter без потери shell consistency;
-- [ ] добавить unit tests на web view route: open/close article web view через `AppState`;
+- [x] добавить unit tests на web view route: open/close article web view через `AppState`;
 - [ ] добавить unit tests на shell action entry points в `AppDependencies`.
 
 #### Sources Screen

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@
 - [x] добавить unit tests для article state transitions.
 
 #### Reading Shell / Navigation
-- [ ] определить финальную модель selection/navigation для `Sources -> Articles -> Article -> WebView`;
+- [x] определить финальную модель selection/navigation для `Sources -> Articles -> Article -> WebView`;
 - [ ] стабилизировать selection при refresh и смене фильтра;
 - [ ] добавить refresh/selection behavior для смены source без рассинхронизации списка и reader;
 - [ ] подготовить entry points для menu / source actions, которые нужны shell-уровню.

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@
 - [x] добавить refresh/selection behavior для смены source без рассинхронизации списка и reader;
 - [x] подготовить entry points для menu / source actions, которые нужны shell-уровню.
 - [x] добавить unit tests на source switch: сброс article/detail selection и reload trigger;
-- [ ] добавить unit tests на filter switch: обновление active filter без потери shell consistency;
+- [x] добавить unit tests на filter switch: обновление active filter без потери shell consistency;
 - [ ] добавить unit tests на web view route: open/close article web view через `AppState`;
 - [ ] добавить unit tests на shell action entry points в `AppDependencies`.
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@
 - [x] определить финальную модель selection/navigation для `Sources -> Articles -> Article -> WebView`;
 - [x] стабилизировать selection при refresh и смене фильтра;
 - [x] добавить refresh/selection behavior для смены source без рассинхронизации списка и reader;
-- [ ] подготовить entry points для menu / source actions, которые нужны shell-уровню.
+- [x] подготовить entry points для menu / source actions, которые нужны shell-уровню.
 
 #### Sources Screen
 - [ ] привести текущий sidebar к дизайну экрана Sources;

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@
 
 #### Reading Shell / Navigation
 - [x] определить финальную модель selection/navigation для `Sources -> Articles -> Article -> WebView`;
-- [ ] стабилизировать selection при refresh и смене фильтра;
+- [x] стабилизировать selection при refresh и смене фильтра;
 - [ ] добавить refresh/selection behavior для смены source без рассинхронизации списка и reader;
 - [ ] подготовить entry points для menu / source actions, которые нужны shell-уровню.
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@
 #### Reading Shell / Navigation
 - [x] определить финальную модель selection/navigation для `Sources -> Articles -> Article -> WebView`;
 - [x] стабилизировать selection при refresh и смене фильтра;
-- [ ] добавить refresh/selection behavior для смены source без рассинхронизации списка и reader;
+- [x] добавить refresh/selection behavior для смены source без рассинхронизации списка и reader;
 - [ ] подготовить entry points для menu / source actions, которые нужны shell-уровню.
 
 #### Sources Screen

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@
 - [x] стабилизировать selection при refresh и смене фильтра;
 - [x] добавить refresh/selection behavior для смены source без рассинхронизации списка и reader;
 - [x] подготовить entry points для menu / source actions, которые нужны shell-уровню.
+- [x] добавить unit tests на source switch: сброс article/detail selection и reload trigger;
+- [ ] добавить unit tests на filter switch: обновление active filter без потери shell consistency;
+- [ ] добавить unit tests на web view route: open/close article web view через `AppState`;
+- [ ] добавить unit tests на shell action entry points в `AppDependencies`.
 
 #### Sources Screen
 - [ ] привести текущий sidebar к дизайну экрана Sources;

--- a/RSSReader/Infrastructure/AppDependencies.swift
+++ b/RSSReader/Infrastructure/AppDependencies.swift
@@ -125,6 +125,41 @@ public extension AppDependencies {
 
 extension AppDependencies {
     @MainActor
+    func showInbox(using appState: AppState) {
+        appState.selectReadingSource(.inbox)
+    }
+
+    @MainActor
+    func showFeed(id feedID: UUID, using appState: AppState) {
+        appState.selectReadingSource(.feed(feedID))
+    }
+
+    @MainActor
+    func selectArticle(id articleID: UUID?, using appState: AppState) {
+        appState.selectedArticleID = articleID
+    }
+
+    @MainActor
+    func applyArticleListFilter(_ filter: ArticleListFilter, using appState: AppState) {
+        appState.selectArticleListFilter(filter)
+    }
+
+    @MainActor
+    func openArticleInWebView(_ article: ReaderArticleDTO, using appState: AppState) {
+        guard let url = URL(string: article.canonicalURL ?? article.articleURL) else {
+            logger.error("Skipped opening article in web view because URL is invalid for article \(article.id)")
+            return
+        }
+
+        appState.presentWebView(articleID: article.id, url: url)
+    }
+
+    @MainActor
+    func closePresentedArticleWebView(using appState: AppState) {
+        appState.dismissPresentedWebView()
+    }
+
+    @MainActor
     func refreshFeed(id feedID: UUID) async -> FeedRefreshResult? {
         guard let feedRefreshService else {
             logger.error("Feed refresh service is unavailable")
@@ -152,6 +187,30 @@ extension AppDependencies {
         }
 
         return await feedRefreshService.refreshAllActiveFeeds()
+    }
+
+    @MainActor
+    func refreshCurrentSource(using appState: AppState) async -> FeedRefreshResult? {
+        switch appState.selectedSidebarSelection {
+        case .feed(let feedID):
+            let result = await refreshFeed(id: feedID)
+            if result != nil {
+                appState.requestArticleListReload()
+            }
+            return result
+        case .inbox, .none:
+            logger.info("Skipped source refresh because the current source is not a single feed")
+            return nil
+        }
+    }
+
+    @MainActor
+    func refreshVisibleSources(using appState: AppState) async -> FeedRefreshBatchResult? {
+        let result = await refreshAllFeeds()
+        if result != nil {
+            appState.requestArticleListReload()
+        }
+        return result
     }
 
     @MainActor

--- a/RSSReader/Infrastructure/AppState.swift
+++ b/RSSReader/Infrastructure/AppState.swift
@@ -1,32 +1,103 @@
 import Foundation
 import Observation
 
-enum SidebarSelection: Hashable, Sendable {
+enum SourceSelection: Hashable, Sendable {
     case inbox
     case feed(UUID)
 }
 
+typealias SidebarSelection = SourceSelection
+
+struct ArticleWebViewRoute: Hashable, Sendable {
+    let articleID: UUID
+    let url: URL
+}
+
+enum ReadingDetailRoute: Hashable, Sendable {
+    case none
+    case article(UUID)
+    case webView(ArticleWebViewRoute)
+}
+
+struct ReadingNavigationState: Hashable, Sendable {
+    var sourceSelection: SourceSelection? = .inbox
+    var articleSelection: UUID? = nil
+    var detailRoute: ReadingDetailRoute = .none
+
+    mutating func selectSource(_ sourceSelection: SourceSelection?) {
+        self.sourceSelection = sourceSelection
+        articleSelection = nil
+        detailRoute = .none
+    }
+
+    mutating func selectArticle(_ articleID: UUID?) {
+        articleSelection = articleID
+        detailRoute = articleID.map(ReadingDetailRoute.article) ?? .none
+    }
+
+    mutating func presentWebView(articleID: UUID, url: URL) {
+        articleSelection = articleID
+        detailRoute = .webView(
+            ArticleWebViewRoute(
+                articleID: articleID,
+                url: url
+            )
+        )
+    }
+
+    mutating func dismissWebView() {
+        detailRoute = articleSelection.map(ReadingDetailRoute.article) ?? .none
+    }
+}
+
 @Observable
 public final class AppState {
-    var selectedSidebarSelection: SidebarSelection? = .inbox
+    var readingNavigation = ReadingNavigationState()
+
+    var selectedSidebarSelection: SidebarSelection? {
+        get { readingNavigation.sourceSelection }
+        set { readingNavigation.selectSource(newValue) }
+    }
 
     public var selectedFeedID: UUID? {
         get {
-            guard case .feed(let feedID) = selectedSidebarSelection else {
+            guard case .feed(let feedID) = readingNavigation.sourceSelection else {
                 return nil
             }
             return feedID
         }
         set {
             if let newValue {
-                selectedSidebarSelection = .feed(newValue)
+                readingNavigation.selectSource(.feed(newValue))
             } else {
-                selectedSidebarSelection = nil
+                readingNavigation.selectSource(nil)
             }
         }
     }
 
-    public var selectedArticleID: UUID? = nil
+    public var selectedArticleID: UUID? {
+        get { readingNavigation.articleSelection }
+        set { readingNavigation.selectArticle(newValue) }
+    }
+
+    var selectedDetailRoute: ReadingDetailRoute {
+        readingNavigation.detailRoute
+    }
+
+    var presentedWebViewRoute: ArticleWebViewRoute? {
+        guard case .webView(let route) = readingNavigation.detailRoute else {
+            return nil
+        }
+        return route
+    }
+
+    func presentWebView(articleID: UUID, url: URL) {
+        readingNavigation.presentWebView(articleID: articleID, url: url)
+    }
+
+    func dismissPresentedWebView() {
+        readingNavigation.dismissWebView()
+    }
 
     public init() {}
 }

--- a/RSSReader/Infrastructure/AppState.swift
+++ b/RSSReader/Infrastructure/AppState.swift
@@ -53,6 +53,8 @@ struct ReadingNavigationState: Hashable, Sendable {
 @Observable
 public final class AppState {
     var readingNavigation = ReadingNavigationState()
+    var selectedArticleListFilter: ArticleListFilter = .all
+    var articleListReloadID = UUID()
 
     var selectedSidebarSelection: SidebarSelection? {
         get { readingNavigation.sourceSelection }
@@ -97,6 +99,14 @@ public final class AppState {
 
     func dismissPresentedWebView() {
         readingNavigation.dismissWebView()
+    }
+
+    func selectArticleListFilter(_ filter: ArticleListFilter) {
+        selectedArticleListFilter = filter
+    }
+
+    func requestArticleListReload() {
+        articleListReloadID = UUID()
     }
 
     public init() {}

--- a/RSSReader/Infrastructure/AppState.swift
+++ b/RSSReader/Infrastructure/AppState.swift
@@ -111,11 +111,10 @@ public final class AppState {
 
     func selectReadingSource(_ sourceSelection: SourceSelection?) {
         let previousSourceSelection = readingNavigation.sourceSelection
-        readingNavigation.selectSource(sourceSelection)
+        guard previousSourceSelection != sourceSelection else { return }
 
-        if previousSourceSelection != sourceSelection {
-            requestArticleListReload()
-        }
+        readingNavigation.selectSource(sourceSelection)
+        requestArticleListReload()
     }
 
     public init() {}

--- a/RSSReader/Infrastructure/AppState.swift
+++ b/RSSReader/Infrastructure/AppState.swift
@@ -58,7 +58,7 @@ public final class AppState {
 
     var selectedSidebarSelection: SidebarSelection? {
         get { readingNavigation.sourceSelection }
-        set { readingNavigation.selectSource(newValue) }
+        set { selectReadingSource(newValue) }
     }
 
     public var selectedFeedID: UUID? {
@@ -70,9 +70,9 @@ public final class AppState {
         }
         set {
             if let newValue {
-                readingNavigation.selectSource(.feed(newValue))
+                selectReadingSource(.feed(newValue))
             } else {
-                readingNavigation.selectSource(nil)
+                selectReadingSource(nil)
             }
         }
     }
@@ -107,6 +107,15 @@ public final class AppState {
 
     func requestArticleListReload() {
         articleListReloadID = UUID()
+    }
+
+    func selectReadingSource(_ sourceSelection: SourceSelection?) {
+        let previousSourceSelection = readingNavigation.sourceSelection
+        readingNavigation.selectSource(sourceSelection)
+
+        if previousSourceSelection != sourceSelection {
+            requestArticleListReload()
+        }
     }
 
     public init() {}

--- a/RSSReader/Views/ArticleListView.swift
+++ b/RSSReader/Views/ArticleListView.swift
@@ -8,6 +8,7 @@ struct ArticleListView: View {
     @Binding var selection: UUID?
     @State private var articles: [ArticleListItemDTO] = []
     @State private var hasLoadedArticles = false
+    @State private var lastLoadedSourceSelection: SidebarSelection? = nil
 
     var body: some View {
         List(articles, id: \.id, selection: $selection) { article in
@@ -52,7 +53,16 @@ struct ArticleListView: View {
 
     @MainActor
     private func loadArticles() async {
-        defer { hasLoadedArticles = true }
+        let sourceSelectionChanged = lastLoadedSourceSelection != selectedSidebarSelection
+        if sourceSelectionChanged {
+            articles = []
+            selection = nil
+            hasLoadedArticles = false
+        }
+        defer {
+            hasLoadedArticles = true
+            lastLoadedSourceSelection = selectedSidebarSelection
+        }
 
         guard let articleQueryService = dependencies.articleQueryService else {
             articles = []

--- a/RSSReader/Views/ArticleListView.swift
+++ b/RSSReader/Views/ArticleListView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ArticleListView: View {
     @Environment(\.appDependencies) private var dependencies
     let selectedSidebarSelection: SidebarSelection?
+    let selectedFilter: ArticleListFilter
+    let reloadID: UUID
     @Binding var selection: UUID?
     @State private var articles: [ArticleListItemDTO] = []
     @State private var hasLoadedArticles = false
@@ -39,7 +41,11 @@ struct ArticleListView: View {
                 }
             }
         }
-        .task(id: selectedSidebarSelection) {
+        .task(id: ArticleListLoadContext(
+            sourceSelection: selectedSidebarSelection,
+            filter: selectedFilter,
+            reloadID: reloadID
+        )) {
             await loadArticles()
         }
     }
@@ -59,9 +65,16 @@ struct ArticleListView: View {
         do {
             switch selectedSidebarSelection {
             case .inbox:
-                articles = try articleQueryService.fetchInboxListItems(sortMode: sortMode)
+                articles = try articleQueryService.fetchInboxListItems(
+                    sortMode: sortMode,
+                    filter: selectedFilter
+                )
             case .feed(let selectedFeedID):
-                articles = try articleQueryService.fetchArticleListItems(feedID: selectedFeedID, sortMode: sortMode)
+                articles = try articleQueryService.fetchArticleListItems(
+                    feedID: selectedFeedID,
+                    sortMode: sortMode,
+                    filter: selectedFilter
+                )
             case .none:
                 articles = []
             }
@@ -70,9 +83,7 @@ struct ArticleListView: View {
             articles = []
         }
 
-        if let selection, articles.contains(where: { $0.id == selection }) == false {
-            self.selection = articles.first?.id
-        }
+        self.selection = stabilizedSelection(availableArticleIDs: articles.map(\.id))
     }
 
     private var emptyStateDescription: String {
@@ -84,6 +95,13 @@ struct ArticleListView: View {
         case .none:
             "Select Inbox or a feed in the sidebar to load articles."
         }
+    }
+
+    private func stabilizedSelection(availableArticleIDs: [UUID]) -> UUID? {
+        if let selection, availableArticleIDs.contains(selection) {
+            return selection
+        }
+        return availableArticleIDs.first
     }
 
     @MainActor
@@ -101,13 +119,25 @@ struct ArticleListView: View {
     }
 }
 
+private struct ArticleListLoadContext: Hashable {
+    let sourceSelection: SidebarSelection?
+    let filter: ArticleListFilter
+    let reloadID: UUID
+}
+
 #Preview {
     struct PreviewContainer: View {
         @State var selection: UUID? = nil
         var body: some View {
-            ArticleListView(selectedSidebarSelection: .inbox, selection: $selection)
+            ArticleListView(
+                selectedSidebarSelection: .inbox,
+                selectedFilter: .all,
+                reloadID: UUID(),
+                selection: $selection
+            )
         }
     }
     return PreviewContainer()
+        .environment(AppState())
         .environment(\.appDependencies, AppDependencies.makeDefault())
 }

--- a/RSSReader/Views/RootView.swift
+++ b/RSSReader/Views/RootView.swift
@@ -16,7 +16,12 @@ struct RootView: View {
         NavigationSplitView {
             SidebarView(selection: sidebarSelection)
         } content: {
-            ArticleListView(selectedSidebarSelection: appState.selectedSidebarSelection, selection: articleSelection)
+            ArticleListView(
+                selectedSidebarSelection: appState.selectedSidebarSelection,
+                selectedFilter: appState.selectedArticleListFilter,
+                reloadID: appState.articleListReloadID,
+                selection: articleSelection
+            )
         } detail: {
             ReaderView(articleID: appState.selectedArticleID)
         }

--- a/RSSReader/Views/RootView.swift
+++ b/RSSReader/Views/RootView.swift
@@ -6,7 +6,7 @@ struct RootView: View {
     var body: some View {
         let sidebarSelection = Binding<SidebarSelection?>(
             get: { appState.selectedSidebarSelection },
-            set: { appState.selectedSidebarSelection = $0 }
+            set: { appState.selectReadingSource($0) }
         )
         let articleSelection = Binding<UUID?>(
             get: { appState.selectedArticleID },

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -773,6 +773,47 @@ struct RSSReaderTests {
         #expect(appState.selectedDetailRoute == .article(articleID))
         #expect(appState.articleListReloadID == reloadIDBeforeReselect)
     }
+
+    @Test
+    func readingShellFilterSwitchUpdatesActiveFilterWithoutBreakingSelectionConsistency() {
+        let appState = AppState()
+        let feedID = UUID()
+        let articleID = UUID()
+
+        appState.selectReadingSource(.feed(feedID))
+        appState.selectedArticleID = articleID
+        let reloadIDBeforeFilterSwitch = appState.articleListReloadID
+
+        appState.selectArticleListFilter(.starred)
+
+        #expect(appState.selectedArticleListFilter == .starred)
+        #expect(appState.selectedSidebarSelection == .feed(feedID))
+        #expect(appState.selectedArticleID == articleID)
+        #expect(appState.selectedDetailRoute == .article(articleID))
+        #expect(appState.presentedWebViewRoute == nil)
+        #expect(appState.articleListReloadID == reloadIDBeforeFilterSwitch)
+    }
+
+    @Test
+    func readingShellApplyingSameFilterKeepsShellStateStable() {
+        let appState = AppState()
+        let articleID = UUID()
+        let webURL = URL(string: "https://example.com/filter-article")!
+
+        appState.selectArticleListFilter(.unread)
+        appState.selectedArticleID = articleID
+        appState.presentWebView(articleID: articleID, url: webURL)
+
+        let reloadIDBeforeReapplyingFilter = appState.articleListReloadID
+
+        appState.selectArticleListFilter(.unread)
+
+        #expect(appState.selectedArticleListFilter == .unread)
+        #expect(appState.selectedArticleID == articleID)
+        #expect(appState.selectedDetailRoute == .webView(ArticleWebViewRoute(articleID: articleID, url: webURL)))
+        #expect(appState.presentedWebViewRoute == ArticleWebViewRoute(articleID: articleID, url: webURL))
+        #expect(appState.articleListReloadID == reloadIDBeforeReapplyingFilter)
+    }
 }
 
 private extension RSSReaderTests {

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -844,6 +844,114 @@ struct RSSReaderTests {
         #expect(appState.selectedDetailRoute == .article(articleID))
         #expect(appState.presentedWebViewRoute == nil)
     }
+
+    @Test
+    func shellActionEntryPointsUpdateSelectionAndFilterInAppState() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appState = AppState()
+        let feedID = UUID()
+        let articleID = UUID()
+
+        harness.dependencies.showFeed(id: feedID, using: appState)
+        harness.dependencies.selectArticle(id: articleID, using: appState)
+        harness.dependencies.applyArticleListFilter(.starred, using: appState)
+
+        #expect(appState.selectedSidebarSelection == .feed(feedID))
+        #expect(appState.selectedArticleID == articleID)
+        #expect(appState.selectedDetailRoute == .article(articleID))
+        #expect(appState.selectedArticleListFilter == .starred)
+
+        harness.dependencies.showInbox(using: appState)
+
+        #expect(appState.selectedSidebarSelection == .inbox)
+        #expect(appState.selectedArticleID == nil)
+        #expect(appState.selectedDetailRoute == .none)
+    }
+
+    @Test
+    func shellActionEntryPointsOpenAndCloseArticleWebViewViaDependencies() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appState = AppState()
+        let feeds = try harness.insertFeeds(urls: ["https://example.com/shell-web.xml"])
+        let feed = try #require(feeds.first)
+        let articleModel = try harness.insertArticle(
+            feed: feed,
+            externalID: "shell-web-article",
+            url: "https://example.com/articles/1",
+            title: "Shell Web Article"
+        )
+        articleModel.canonicalURL = "https://example.com/articles/1/canonical"
+        try harness.saveModelContext()
+        let readerArticle = try harness.dependencies.articleQueryService?.fetchReaderArticle(id: articleModel.id)
+        let article = try #require(readerArticle)
+
+        harness.dependencies.selectArticle(id: article.id, using: appState)
+        harness.dependencies.openArticleInWebView(article, using: appState)
+
+        #expect(appState.selectedDetailRoute == .webView(ArticleWebViewRoute(articleID: article.id, url: URL(string: "https://example.com/articles/1/canonical")!)))
+        #expect(appState.presentedWebViewRoute == ArticleWebViewRoute(articleID: article.id, url: URL(string: "https://example.com/articles/1/canonical")!))
+
+        harness.dependencies.closePresentedArticleWebView(using: appState)
+
+        #expect(appState.selectedDetailRoute == .article(article.id))
+        #expect(appState.presentedWebViewRoute == nil)
+    }
+
+    @Test
+    func shellActionEntryPointsRefreshCurrentSourceTriggersReloadAfterFeedRefresh() async throws {
+        let client = ScriptedHTTPClient(
+            responsesByURL: [
+                "https://example.com/shell-refresh-current.xml": .response(
+                    statusCode: 304,
+                    headers: ["ETag": "\"etag-shell-current\""],
+                    body: ""
+                )
+            ]
+        )
+        let harness = try TestHarness.make(httpClient: client)
+        let appState = AppState()
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/shell-refresh-current.xml"]).first)
+        let reloadIDBeforeRefresh = appState.articleListReloadID
+
+        harness.dependencies.showFeed(id: feed.id, using: appState)
+        let reloadIDAfterSourceSelection = appState.articleListReloadID
+
+        let result = await harness.dependencies.refreshCurrentSource(using: appState)
+
+        #expect(result?.status == .notModified)
+        #expect(appState.articleListReloadID != reloadIDAfterSourceSelection)
+        #expect(appState.articleListReloadID != reloadIDBeforeRefresh)
+    }
+
+    @Test
+    func shellActionEntryPointsRefreshVisibleSourcesTriggersReloadAfterBatchRefresh() async throws {
+        let urls = [
+            "https://example.com/shell-refresh-all-1.xml",
+            "https://example.com/shell-refresh-all-2.xml"
+        ]
+        let responses = [
+            urls[0]: ScriptedHTTPClient.Step.response(
+                statusCode: 304,
+                headers: ["ETag": "\"etag-shell-all-1\""],
+                body: ""
+            ),
+            urls[1]: ScriptedHTTPClient.Step.response(
+                statusCode: 304,
+                headers: ["ETag": "\"etag-shell-all-2\""],
+                body: ""
+            )
+        ]
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient(responsesByURL: responses))
+        let appState = AppState()
+        _ = try harness.insertFeeds(urls: urls)
+        let reloadIDBeforeRefresh = appState.articleListReloadID
+
+        let result = await harness.dependencies.refreshVisibleSources(using: appState)
+
+        #expect(result?.summary.totalFeedCount == 2)
+        #expect(result?.summary.notModifiedCount == 2)
+        #expect(appState.articleListReloadID != reloadIDBeforeRefresh)
+    }
 }
 
 private extension RSSReaderTests {
@@ -879,6 +987,7 @@ private extension RSSReaderTests {
 }
 
 private struct TestHarness {
+    let dependencies: AppDependencies
     let modelContainer: ModelContainer
     let feedRepository: SwiftDataFeedRepository
     let articleRepository: SwiftDataArticleRepository
@@ -901,6 +1010,16 @@ private struct TestHarness {
         let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
         let modelContainer = try ModelContainer(for: schema, configurations: [configuration])
         let modelContext = modelContainer.mainContext
+        let feedFetcher = FeedFetcher(
+            httpClient: httpClient,
+            retryPolicy: FeedRetryPolicy(maxAttempts: 1, baseDelayNanoseconds: 0)
+        )
+        let dependencies = AppDependencies(
+            logger: TestLogger(),
+            httpClient: httpClient,
+            feedFetcher: feedFetcher,
+            modelContainer: modelContainer
+        )
 
         let feedRepository = SwiftDataFeedRepository(modelContext: modelContext)
         let articleRepository = SwiftDataArticleRepository(modelContext: modelContext)
@@ -922,6 +1041,7 @@ private struct TestHarness {
         )
 
         return TestHarness(
+            dependencies: dependencies,
             modelContainer: modelContainer,
             feedRepository: feedRepository,
             articleRepository: articleRepository,

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -731,6 +731,48 @@ struct RSSReaderTests {
         #expect(state.lastInteractionAt == newerTimestamp)
         #expect(state.updatedAt == newerTimestamp)
     }
+
+    @Test
+    func readingShellSourceSwitchResetsArticleDetailSelectionAndTriggersReload() {
+        let appState = AppState()
+        let initialReloadID = appState.articleListReloadID
+        let feedID = UUID()
+        let articleID = UUID()
+
+        appState.selectReadingSource(.feed(feedID))
+        appState.selectedArticleID = articleID
+        appState.presentWebView(articleID: articleID, url: URL(string: "https://example.com/article")!)
+
+        let reloadIDBeforeSwitch = appState.articleListReloadID
+
+        appState.selectReadingSource(.inbox)
+
+        #expect(appState.selectedSidebarSelection == .inbox)
+        #expect(appState.selectedArticleID == nil)
+        #expect(appState.selectedDetailRoute == .none)
+        #expect(appState.presentedWebViewRoute == nil)
+        #expect(reloadIDBeforeSwitch != initialReloadID)
+        #expect(appState.articleListReloadID != reloadIDBeforeSwitch)
+    }
+
+    @Test
+    func readingShellSelectingSameSourceDoesNotResetSelectionOrTriggerReload() {
+        let appState = AppState()
+        let feedID = UUID()
+        let articleID = UUID()
+
+        appState.selectReadingSource(.feed(feedID))
+        appState.selectedArticleID = articleID
+
+        let reloadIDBeforeReselect = appState.articleListReloadID
+
+        appState.selectReadingSource(.feed(feedID))
+
+        #expect(appState.selectedSidebarSelection == .feed(feedID))
+        #expect(appState.selectedArticleID == articleID)
+        #expect(appState.selectedDetailRoute == .article(articleID))
+        #expect(appState.articleListReloadID == reloadIDBeforeReselect)
+    }
 }
 
 private extension RSSReaderTests {

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -814,6 +814,36 @@ struct RSSReaderTests {
         #expect(appState.presentedWebViewRoute == ArticleWebViewRoute(articleID: articleID, url: webURL))
         #expect(appState.articleListReloadID == reloadIDBeforeReapplyingFilter)
     }
+
+    @Test
+    func readingShellOpenArticleWebViewSetsPresentedRouteAndPreservesArticleContext() {
+        let appState = AppState()
+        let articleID = UUID()
+        let webURL = URL(string: "https://example.com/webview-article")!
+
+        appState.selectedArticleID = articleID
+        appState.presentWebView(articleID: articleID, url: webURL)
+
+        #expect(appState.selectedArticleID == articleID)
+        #expect(appState.selectedDetailRoute == .webView(ArticleWebViewRoute(articleID: articleID, url: webURL)))
+        #expect(appState.presentedWebViewRoute == ArticleWebViewRoute(articleID: articleID, url: webURL))
+    }
+
+    @Test
+    func readingShellClosingArticleWebViewRestoresArticleDetailRoute() {
+        let appState = AppState()
+        let articleID = UUID()
+        let webURL = URL(string: "https://example.com/webview-close")!
+
+        appState.selectedArticleID = articleID
+        appState.presentWebView(articleID: articleID, url: webURL)
+
+        appState.dismissPresentedWebView()
+
+        #expect(appState.selectedArticleID == articleID)
+        #expect(appState.selectedDetailRoute == .article(articleID))
+        #expect(appState.presentedWebViewRoute == nil)
+    }
 }
 
 private extension RSSReaderTests {


### PR DESCRIPTION
## Кратко
Задача Reading Shell / Navigation выполнена

Реализовано:
- [x] определить финальную модель selection/navigation для `Sources -> Articles -> Article -> WebView`;
- [x] стабилизировать selection при refresh и смене фильтра;
- [x] добавить refresh/selection behavior для смены source без рассинхронизации списка и reader;
- [x] подготовить entry points для menu / source actions, которые нужны shell-уровню.
- [x] добавить unit tests на source switch: сброс article/detail selection и reload trigger;
- [x] добавить unit tests на filter switch: обновление active filter без потери shell consistency;
- [x] добавить unit tests на web view route: open/close article web view через `AppState`;
- [x] добавить unit tests на shell action entry points в `AppDependencies`.

## Закрывает
Closes #96 
Closes #97 
Closes #98 
Closes #99 
Closes #245 
Closes #246 
Closes #247 
Closes #248 
Closes #95 