### PR TITLE
Article Screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@
 - [x] связать нажатие на кнопку `open in app-browser` с app-level navigation entry point, чтобы `Article Screen` открывал `WebView Screen` через app-level routing без прямого знания о shell-роутинге;
 - [x] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;
 - [x] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
-- [ ] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;
+- [x] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;
 - [ ] подготовить extension point под future full text flow: зафиксировать, где будет жить логика `full text` extraction, как она влияет на `ReaderArticleDTO`/presentation model и чем базовый embedded reader отличается от отдельного reader mode;
 - [ ] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, bottom actions и переход в `WebView Screen`.
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@
 - [x] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
 - [x] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;
 - [x] подготовить extension point под future full text flow: зафиксировать, где будет жить логика `full text` extraction, как она влияет на `ReaderArticleDTO`/presentation model и чем базовый embedded reader отличается от отдельного reader mode;
-- [ ] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, bottom actions и переход в `WebView Screen`.
+- [x] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, bottom actions и переход в `WebView Screen`.
 
 #### WebView Screen
 - [ ] создать отдельный экран WebView для `articleURL`;

--- a/README.md
+++ b/README.md
@@ -224,12 +224,20 @@
 - [x] добавить недостающие тесты именно на refresh UX. Сейчас покрыт state-level failure path, но полезно отдельно зафиксировать сценарии successful refresh clears previous refresh error и selection change resets stale refresh feedback.
 
 #### Article Screen
-- [ ] привести текущий reader к дизайну экрана Article;
-- [ ] оформить header: title / source / date / author;
-- [ ] улучшить rendering summary/content/plain text;
-- [ ] добавить actions: `mark unread`, `star/unstar`, `share`, `open in browser`;
-- [ ] реализовать `markAsReadOnOpen` на основе `AppSettings`;
-- [ ] связать экран со state actions из `ArticleStateService`.
+- [x] определить screen-level state/model для `Article Screen`, чтобы отделить загрузку статьи, toolbar actions, menu state, `share`, error/empty состояния и rendering policy от `ReaderView`;
+- [ ] определить compact navigation flow экрана: toolbar с back button слева, без отдельного title в navigation bar, возврат на `Articles Screen` по кнопке и системному back behavior;
+- [ ] зафиксировать action placement policy для `Article Screen`: стартовый вариант — `share` и menu actions в правой части toolbar, альтернативный вариант с bottom actions bar оставить как отдельное UX-решение после первой рабочей версии;
+- [ ] оформить header контента в порядке `publishedAt` / `title` / `author` / `feedTitle`, включая правила скрытия пустых полей и единый formatter для даты и времени публикации;
+- [ ] улучшить content rendering pipeline: выбрать лучший доступный источник между `contentHTML`, `contentText`, `summary`, поддержать многоабзацный текст, inline images и аккуратный fallback для статей без полного тела;
+- [ ] определить presentation model для body content, чтобы преобразование `ReaderArticleDTO` в блоки интерфейса не жило внутри `View` и позже могло быть расширено под richer rendering;
+- [ ] добавить toolbar/menu actions: `share`, `star/unstar`, `mark unread` / `mark read`, `open in app-browser`;
+- [ ] связать actions экрана с `ArticleStateService` и app-level navigation entry points, чтобы `ReaderView` не вызывал repository/query/state слой напрямую;
+- [ ] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
+- [ ] подготовить открытие статьи в отдельном `WebView Screen` через `AppState.presentWebView(articleID:url:)`, чтобы menu action `open in app-browser` использовал уже существующий navigation shell;
+- [ ] добавить `share` flow через системный sheet с canonical article URL и корректным fallback на `articleURL`;
+- [ ] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;
+- [ ] подготовить extension point под future full text flow: зафиксировать, где будет жить логика `full text` extraction, как она влияет на `ReaderArticleDTO`/presentation model и чем базовый embedded reader отличается от отдельного reader mode;
+- [ ] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, menu actions и переход в `WebView Screen`.
 
 #### WebView Screen
 - [ ] создать отдельный экран WebView для `articleURL`;

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@
 - [x] добавить `share` в правую часть top bar и нижние actions `mark unread`, `star`, `open in app-browser` как три раздельные bottom bar кнопки;
 - [x] связать нажатие на read toggle кнопку с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать `read` status статьи в обе стороны с иконкой `circle` / `circle.fill`;
 - [x] связать нажатие на кнопку `star` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `star` / `star.fill` по текущему `starred` status статьи;
-- [ ] связать нажатие на кнопку `open in app-browser` с app-level navigation entry point, чтобы `Article Screen` открывал уже существующий `WebView Screen` без прямого знания о shell-роутинге;
+- [x] связать нажатие на кнопку `open in app-browser` с app-level navigation entry point, чтобы `Article Screen` открывал `WebView Screen` через app-level routing без прямого знания о shell-роутинге;
 - [ ] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;
 - [ ] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
 - [ ] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@
 - [x] определить screen-level state/model для `Article Screen`, чтобы отделить загрузку статьи, toolbar actions, menu state, `share`, error/empty состояния и rendering policy от `ReaderView`;
 - [x] определить compact navigation flow экрана: toolbar с back button слева, без отдельного title в navigation bar, возврат на `Articles Screen` по кнопке и системному back behavior;
 - [x] оформить header контента в порядке `publishedAt` / `title` / `author` / `feedTitle`, включая правила скрытия пустых полей и единый formatter для даты и времени публикации;
-- [ ] улучшить content rendering pipeline: выбрать лучший доступный источник между `contentHTML`, `contentText`, `summary`, поддержать многоабзацный текст, inline images и аккуратный fallback для статей без полного тела;
+- [x] улучшить content rendering pipeline: выбрать лучший доступный источник между `contentHTML`, `contentText`, `summary`, поддержать многоабзацный текст, inline images и аккуратный fallback для статей без полного тела;
 - [ ] определить presentation model для body content, чтобы преобразование `ReaderArticleDTO` в блоки интерфейса не жило внутри `View` и позже могло быть расширено под richer rendering;
 - [ ] добавить toolbar/menu actions: `share`, `star/unstar`, `mark unread` / `mark read`, `open in app-browser`;
 - [ ] связать actions экрана с `ArticleStateService` и app-level navigation entry points, чтобы `ReaderView` не вызывал repository/query/state слой напрямую;

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@
 - [x] оформить header контента в порядке `publishedAt` / `title` / `author` / `feedTitle`, включая правила скрытия пустых полей и единый formatter для даты и времени публикации;
 - [x] улучшить content rendering pipeline: выбрать лучший доступный источник между `contentHTML`, `contentText`, `summary`, поддержать многоабзацный текст, inline images и аккуратный fallback для статей без полного тела;
 - [x] добавить `share` в правую часть top bar и нижние actions `mark unread`, `star`, `open in app-browser` как три раздельные bottom bar кнопки;
-- [ ] связать нажатие на кнопку `mark unread` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `circle` / `circle.fill` по текущему `read` status статьи;
+- [x] связать нажатие на read toggle кнопку с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать `read` status статьи в обе стороны с иконкой `circle` / `circle.fill`;
 - [ ] связать нажатие на кнопку `star` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `star` / `star.fill` по текущему `starred` status статьи;
 - [ ] связать нажатие на кнопку `open in app-browser` с app-level navigation entry point, чтобы `Article Screen` открывал уже существующий `WebView Screen` без прямого знания о shell-роутинге;
 - [ ] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@
 - [x] связать нажатие на кнопку `star` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `star` / `star.fill` по текущему `starred` status статьи;
 - [x] связать нажатие на кнопку `open in app-browser` с app-level navigation entry point, чтобы `Article Screen` открывал `WebView Screen` через app-level routing без прямого знания о shell-роутинге;
 - [x] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;
-- [ ] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
+- [x] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
 - [ ] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;
 - [ ] подготовить extension point под future full text flow: зафиксировать, где будет жить логика `full text` extraction, как она влияет на `ReaderArticleDTO`/presentation model и чем базовый embedded reader отличается от отдельного reader mode;
 - [ ] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, bottom actions и переход в `WebView Screen`.

--- a/README.md
+++ b/README.md
@@ -228,15 +228,15 @@
 - [x] определить compact navigation flow экрана: toolbar с back button слева, без отдельного title в navigation bar, возврат на `Articles Screen` по кнопке и системному back behavior;
 - [x] оформить header контента в порядке `publishedAt` / `title` / `author` / `feedTitle`, включая правила скрытия пустых полей и единый formatter для даты и времени публикации;
 - [x] улучшить content rendering pipeline: выбрать лучший доступный источник между `contentHTML`, `contentText`, `summary`, поддержать многоабзацный текст, inline images и аккуратный fallback для статей без полного тела;
-- [ ] определить presentation model для body content, чтобы преобразование `ReaderArticleDTO` в блоки интерфейса не жило внутри `View` и позже могло быть расширено под richer rendering;
-- [ ] добавить toolbar/menu actions: `share`, `star/unstar`, `mark unread` / `mark read`, `open in app-browser`;
-- [ ] связать actions экрана с `ArticleStateService` и app-level navigation entry points, чтобы `ReaderView` не вызывал repository/query/state слой напрямую;
+- [x] добавить `share` в правую часть top bar и нижние actions `mark unread`, `star`, `open in app-browser` как три раздельные bottom bar кнопки;
+- [ ] связать нажатие на кнопку `mark unread` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `circle` / `circle.fill` по текущему `read` status статьи;
+- [ ] связать нажатие на кнопку `star` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `star` / `star.fill` по текущему `starred` status статьи;
+- [ ] связать нажатие на кнопку `open in app-browser` с app-level navigation entry point, чтобы `Article Screen` открывал уже существующий `WebView Screen` без прямого знания о shell-роутинге;
+- [ ] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;
 - [ ] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
-- [ ] подготовить открытие статьи в отдельном `WebView Screen` через `AppState.presentWebView(articleID:url:)`, чтобы menu action `open in app-browser` использовал уже существующий navigation shell;
-- [ ] добавить `share` flow через системный sheet с canonical article URL и корректным fallback на `articleURL`;
 - [ ] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;
 - [ ] подготовить extension point под future full text flow: зафиксировать, где будет жить логика `full text` extraction, как она влияет на `ReaderArticleDTO`/presentation model и чем базовый embedded reader отличается от отдельного reader mode;
-- [ ] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, menu actions и переход в `WebView Screen`.
+- [ ] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, bottom actions и переход в `WebView Screen`.
 
 #### WebView Screen
 - [ ] создать отдельный экран WebView для `articleURL`;

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@
 - [x] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;
 - [x] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
 - [x] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;
-- [ ] подготовить extension point под future full text flow: зафиксировать, где будет жить логика `full text` extraction, как она влияет на `ReaderArticleDTO`/presentation model и чем базовый embedded reader отличается от отдельного reader mode;
+- [x] подготовить extension point под future full text flow: зафиксировать, где будет жить логика `full text` extraction, как она влияет на `ReaderArticleDTO`/presentation model и чем базовый embedded reader отличается от отдельного reader mode;
 - [ ] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, bottom actions и переход в `WebView Screen`.
 
 #### WebView Screen

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@
 
 #### Article Screen
 - [x] определить screen-level state/model для `Article Screen`, чтобы отделить загрузку статьи, toolbar actions, menu state, `share`, error/empty состояния и rendering policy от `ReaderView`;
-- [ ] определить compact navigation flow экрана: toolbar с back button слева, без отдельного title в navigation bar, возврат на `Articles Screen` по кнопке и системному back behavior;
+- [x] определить compact navigation flow экрана: toolbar с back button слева, без отдельного title в navigation bar, возврат на `Articles Screen` по кнопке и системному back behavior;
 - [ ] зафиксировать action placement policy для `Article Screen`: стартовый вариант — `share` и menu actions в правой части toolbar, альтернативный вариант с bottom actions bar оставить как отдельное UX-решение после первой рабочей версии;
 - [ ] оформить header контента в порядке `publishedAt` / `title` / `author` / `feedTitle`, включая правила скрытия пустых полей и единый formatter для даты и времени публикации;
 - [ ] улучшить content rendering pipeline: выбрать лучший доступный источник между `contentHTML`, `contentText`, `summary`, поддержать многоабзацный текст, inline images и аккуратный fallback для статей без полного тела;

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@
 - [x] связать нажатие на read toggle кнопку с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать `read` status статьи в обе стороны с иконкой `circle` / `circle.fill`;
 - [x] связать нажатие на кнопку `star` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `star` / `star.fill` по текущему `starred` status статьи;
 - [x] связать нажатие на кнопку `open in app-browser` с app-level navigation entry point, чтобы `Article Screen` открывал `WebView Screen` через app-level routing без прямого знания о shell-роутинге;
-- [ ] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;
+- [x] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;
 - [ ] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
 - [ ] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;
 - [ ] подготовить extension point под future full text flow: зафиксировать, где будет жить логика `full text` extraction, как она влияет на `ReaderArticleDTO`/presentation model и чем базовый embedded reader отличается от отдельного reader mode;

--- a/README.md
+++ b/README.md
@@ -226,8 +226,7 @@
 #### Article Screen
 - [x] определить screen-level state/model для `Article Screen`, чтобы отделить загрузку статьи, toolbar actions, menu state, `share`, error/empty состояния и rendering policy от `ReaderView`;
 - [x] определить compact navigation flow экрана: toolbar с back button слева, без отдельного title в navigation bar, возврат на `Articles Screen` по кнопке и системному back behavior;
-- [ ] зафиксировать action placement policy для `Article Screen`: стартовый вариант — `share` и menu actions в правой части toolbar, альтернативный вариант с bottom actions bar оставить как отдельное UX-решение после первой рабочей версии;
-- [ ] оформить header контента в порядке `publishedAt` / `title` / `author` / `feedTitle`, включая правила скрытия пустых полей и единый formatter для даты и времени публикации;
+- [x] оформить header контента в порядке `publishedAt` / `title` / `author` / `feedTitle`, включая правила скрытия пустых полей и единый formatter для даты и времени публикации;
 - [ ] улучшить content rendering pipeline: выбрать лучший доступный источник между `contentHTML`, `contentText`, `summary`, поддержать многоабзацный текст, inline images и аккуратный fallback для статей без полного тела;
 - [ ] определить presentation model для body content, чтобы преобразование `ReaderArticleDTO` в блоки интерфейса не жило внутри `View` и позже могло быть расширено под richer rendering;
 - [ ] добавить toolbar/menu actions: `share`, `star/unstar`, `mark unread` / `mark read`, `open in app-browser`;

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@
 - [x] улучшить content rendering pipeline: выбрать лучший доступный источник между `contentHTML`, `contentText`, `summary`, поддержать многоабзацный текст, inline images и аккуратный fallback для статей без полного тела;
 - [x] добавить `share` в правую часть top bar и нижние actions `mark unread`, `star`, `open in app-browser` как три раздельные bottom bar кнопки;
 - [x] связать нажатие на read toggle кнопку с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать `read` status статьи в обе стороны с иконкой `circle` / `circle.fill`;
-- [ ] связать нажатие на кнопку `star` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `star` / `star.fill` по текущему `starred` status статьи;
+- [x] связать нажатие на кнопку `star` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `star` / `star.fill` по текущему `starred` status статьи;
 - [ ] связать нажатие на кнопку `open in app-browser` с app-level navigation entry point, чтобы `Article Screen` открывал уже существующий `WebView Screen` без прямого знания о shell-роутинге;
 - [ ] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;
 - [ ] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;

--- a/RSSReader/Services/Queries/ReaderArticleDTO.swift
+++ b/RSSReader/Services/Queries/ReaderArticleDTO.swift
@@ -101,4 +101,31 @@ struct ReaderArticleDTO: Sendable, Identifiable {
         self.isStarred = state?.isStarred ?? false
         self.isHidden = state?.isHidden ?? false
     }
+
+    func updating(
+        isRead: Bool? = nil,
+        isStarred: Bool? = nil,
+        isHidden: Bool? = nil
+    ) -> ReaderArticleDTO {
+        ReaderArticleDTO(
+            id: id,
+            feedID: feedID,
+            feedTitle: feedTitle,
+            feedSiteURL: feedSiteURL,
+            articleExternalID: articleExternalID,
+            title: title,
+            summary: summary,
+            contentHTML: contentHTML,
+            contentText: contentText,
+            author: author,
+            publishedAt: publishedAt,
+            updatedAtSource: updatedAtSource,
+            articleURL: articleURL,
+            canonicalURL: canonicalURL,
+            imageURL: imageURL,
+            isRead: isRead ?? self.isRead,
+            isStarred: isStarred ?? self.isStarred,
+            isHidden: isHidden ?? self.isHidden
+        )
+    }
 }

--- a/RSSReader/Services/Queries/ReaderArticleDTO.swift
+++ b/RSSReader/Services/Queries/ReaderArticleDTO.swift
@@ -20,6 +20,46 @@ struct ReaderArticleDTO: Sendable, Identifiable {
     let isStarred: Bool
     let isHidden: Bool
 
+    init(
+        id: UUID,
+        feedID: UUID,
+        feedTitle: String,
+        feedSiteURL: String?,
+        articleExternalID: String,
+        title: String,
+        summary: String?,
+        contentHTML: String?,
+        contentText: String?,
+        author: String?,
+        publishedAt: Date?,
+        updatedAtSource: Date?,
+        articleURL: String,
+        canonicalURL: String?,
+        imageURL: String?,
+        isRead: Bool,
+        isStarred: Bool,
+        isHidden: Bool
+    ) {
+        self.id = id
+        self.feedID = feedID
+        self.feedTitle = feedTitle
+        self.feedSiteURL = feedSiteURL
+        self.articleExternalID = articleExternalID
+        self.title = title
+        self.summary = summary
+        self.contentHTML = contentHTML
+        self.contentText = contentText
+        self.author = author
+        self.publishedAt = publishedAt
+        self.updatedAtSource = updatedAtSource
+        self.articleURL = articleURL
+        self.canonicalURL = canonicalURL
+        self.imageURL = imageURL
+        self.isRead = isRead
+        self.isStarred = isStarred
+        self.isHidden = isHidden
+    }
+
     init(article: Article, state: ArticleState?) {
         self.id = article.id
         self.feedID = article.feedID

--- a/RSSReader/Views/ArticleScreen/ArticleScreenContentRenderer.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenContentRenderer.swift
@@ -10,6 +10,9 @@ enum ArticleScreenBodyBlock: Equatable {
 @MainActor
 enum ArticleScreenContentRenderer {
     static func renderBody(for article: ReaderArticleDTO) -> ArticleScreenBodyContentState {
+        // TODO: When full-text extraction is implemented, resolve extracted content upstream
+        // and construct ArticleScreenBodyContentState.extractedFullText(...) here without
+        // teaching ReaderView a separate full-text rendering path.
         if let contentHTML = article.contentHTML?.nilIfBlank {
             let htmlBlocks = renderHTML(contentHTML, article: article)
             if htmlBlocks.isEmpty == false {

--- a/RSSReader/Views/ArticleScreen/ArticleScreenContentRenderer.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenContentRenderer.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+@MainActor
+enum ArticleScreenBodyBlock: Equatable {
+    case paragraph(String)
+    case image(URL)
+    case fallbackNotice(String)
+}
+
+@MainActor
+enum ArticleScreenContentRenderer {
+    static func renderBody(for article: ReaderArticleDTO) -> ArticleScreenBodyContentState {
+        if let contentHTML = article.contentHTML?.nilIfBlank {
+            let htmlBlocks = renderHTML(contentHTML, article: article)
+            if htmlBlocks.isEmpty == false {
+                return ArticleScreenBodyContentState(
+                    blocks: appendLeadImageIfNeeded(htmlBlocks, article: article),
+                    source: .contentHTML
+                )
+            }
+        }
+
+        if let contentText = article.contentText?.nilIfBlank {
+            let textBlocks = renderTextBlock(contentText)
+            if textBlocks.isEmpty == false {
+                return ArticleScreenBodyContentState(
+                    blocks: appendLeadImageIfNeeded(textBlocks, article: article),
+                    source: .contentText
+                )
+            }
+        }
+
+        if let summary = article.summary?.nilIfBlank {
+            var summaryBlocks = renderTextBlock(summary)
+            summaryBlocks = appendLeadImageIfNeeded(summaryBlocks, article: article)
+            summaryBlocks.append(
+                ArticleScreenBodyBlock.fallbackNotice(
+                    "This source only provides a summary, not the full article body."
+                )
+            )
+
+            return ArticleScreenBodyContentState(
+                blocks: summaryBlocks,
+                source: .summary
+            )
+        }
+
+        var fallbackBlocks: [ArticleScreenBodyBlock] = []
+        if let imageBlock = leadImageBlock(for: article) {
+            fallbackBlocks.append(imageBlock)
+        }
+        fallbackBlocks.append(
+            ArticleScreenBodyBlock.fallbackNotice("Full article content is unavailable in this feed.")
+        )
+
+        return ArticleScreenBodyContentState(
+            blocks: fallbackBlocks,
+            source: .empty
+        )
+    }
+
+    private static func renderHTML(
+        _ contentHTML: String,
+        article: ReaderArticleDTO
+    ) -> [ArticleScreenBodyBlock] {
+        let htmlNSString = contentHTML as NSString
+        let imageTagPattern = #"<img\b[^>]*>"#
+        guard let imageTagRegex = try? NSRegularExpression(pattern: imageTagPattern, options: [.caseInsensitive]) else {
+            return renderTextBlock(stripHTML(contentHTML))
+        }
+
+        var blocks: [ArticleScreenBodyBlock] = []
+        var currentLocation = 0
+        let matches = imageTagRegex.matches(
+            in: contentHTML,
+            options: [],
+            range: NSRange(location: 0, length: htmlNSString.length)
+        )
+
+        for match in matches {
+            let textRange = NSRange(location: currentLocation, length: match.range.location - currentLocation)
+            if textRange.length > 0 {
+                let textSegment = htmlNSString.substring(with: textRange)
+                blocks.append(contentsOf: renderTextBlock(stripHTML(textSegment)))
+            }
+
+            let imageTag = htmlNSString.substring(with: match.range)
+            if let imageURL = resolveImageURL(fromImageTag: imageTag, article: article) {
+                blocks.append(.image(imageURL))
+            }
+
+            currentLocation = match.range.location + match.range.length
+        }
+
+        if currentLocation < htmlNSString.length {
+            let trailingRange = NSRange(location: currentLocation, length: htmlNSString.length - currentLocation)
+            let trailingSegment = htmlNSString.substring(with: trailingRange)
+            blocks.append(contentsOf: renderTextBlock(stripHTML(trailingSegment)))
+        }
+
+        return blocks
+    }
+
+    private static func renderTextBlock(_ text: String) -> [ArticleScreenBodyBlock] {
+        text
+            .normalizedParagraphs
+            .map(ArticleScreenBodyBlock.paragraph)
+    }
+
+    private static func appendLeadImageIfNeeded(
+        _ blocks: [ArticleScreenBodyBlock],
+        article: ReaderArticleDTO
+    ) -> [ArticleScreenBodyBlock] {
+        guard blocks.containsImageBlock == false, let imageBlock = leadImageBlock(for: article) else {
+            return blocks
+        }
+
+        return [imageBlock] + blocks
+    }
+
+    private static func leadImageBlock(for article: ReaderArticleDTO) -> ArticleScreenBodyBlock? {
+        guard
+            let imageURLString = article.imageURL?.nilIfBlank,
+            let imageURL = ArticleScreenURLResolver.resolveMediaURL(
+                rawValue: imageURLString,
+                baseURLString: article.canonicalURL ?? article.articleURL
+            )
+        else {
+            return nil
+        }
+
+        return .image(imageURL)
+    }
+
+    private static func resolveImageURL(
+        fromImageTag imageTag: String,
+        article: ReaderArticleDTO
+    ) -> URL? {
+        let srcPattern = #"src\s*=\s*["']?([^"' >]+)"?"#
+        guard
+            let srcRegex = try? NSRegularExpression(pattern: srcPattern, options: [.caseInsensitive]),
+            let match = srcRegex.firstMatch(
+                in: imageTag,
+                options: [],
+                range: NSRange(location: 0, length: (imageTag as NSString).length)
+            ),
+            match.numberOfRanges > 1
+        else {
+            return nil
+        }
+
+        let rawImageURL = (imageTag as NSString).substring(with: match.range(at: 1))
+        return ArticleScreenURLResolver.resolveMediaURL(
+            rawValue: rawImageURL,
+            baseURLString: article.canonicalURL ?? article.articleURL
+        )
+    }
+
+    private static func stripHTML(_ value: String) -> String {
+        value
+            .replacingOccurrences(
+                of: #"(?i)<br\s*/?>"#,
+                with: "\n",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: #"(?i)</?(p|div|section|article|blockquote|ul|ol|li|h[1-6]|pre)\b[^>]*>"#,
+                with: "\n\n",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: #"<[^>]+>"#,
+                with: "",
+                options: .regularExpression
+            )
+            .decodingBasicHTMLEntities()
+    }
+}
+
+private extension Array where Element == ArticleScreenBodyBlock {
+    var containsImageBlock: Bool {
+        contains {
+            if case .image = $0 {
+                return true
+            }
+            return false
+        }
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let trimmedValue = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? nil : trimmedValue
+    }
+
+    var normalizedParagraphs: [String] {
+        replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: "\n\n")
+            .map { paragraph in
+                paragraph
+                    .components(separatedBy: .newlines)
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { $0.isEmpty == false }
+                    .joined(separator: " ")
+            }
+            .filter { $0.isEmpty == false }
+    }
+
+    func decodingBasicHTMLEntities() -> String {
+        self
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+    }
+}

--- a/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
@@ -27,7 +27,11 @@ final class ArticleScreenController {
 
         do {
             if let article = try articleQueryService.fetchReaderArticle(id: articleID) {
-                screenState.applyLoadedArticle(article)
+                let resolvedArticle = applyMarkAsReadOnOpenPolicy(
+                    to: article,
+                    dependencies: dependencies
+                )
+                screenState.applyLoadedArticle(resolvedArticle)
             } else {
                 screenState.applyArticleNotFound(articleID: articleID)
             }
@@ -110,5 +114,48 @@ final class ArticleScreenController {
     ) {
         guard let article = screenState.article else { return }
         dependencies.openArticleInWebView(article, using: appState)
+    }
+
+    private func applyMarkAsReadOnOpenPolicy(
+        to article: ReaderArticleDTO,
+        dependencies: AppDependencies
+    ) -> ReaderArticleDTO {
+        guard article.isRead == false else {
+            return article
+        }
+
+        guard shouldMarkAsReadOnOpen(dependencies: dependencies) else {
+            return article
+        }
+
+        guard let articleStateService = dependencies.articleStateService else {
+            dependencies.logger.error("Article state service is unavailable for mark-as-read-on-open policy")
+            return article
+        }
+
+        do {
+            _ = try articleStateService.markAsRead(
+                feedID: article.feedID,
+                articleExternalID: article.articleExternalID,
+                at: .now
+            )
+            return article.updating(isRead: true)
+        } catch {
+            dependencies.logger.error("Failed to apply mark-as-read-on-open policy: \(error)")
+            return article
+        }
+    }
+
+    private func shouldMarkAsReadOnOpen(dependencies: AppDependencies) -> Bool {
+        guard let appSettingsRepository = dependencies.appSettingsRepository else {
+            return true
+        }
+
+        do {
+            return try appSettingsRepository.fetchOrCreate().markAsReadOnOpen
+        } catch {
+            dependencies.logger.error("Failed to load app settings for mark-as-read-on-open policy: \(error)")
+            return true
+        }
     }
 }

--- a/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
@@ -40,14 +40,6 @@ final class ArticleScreenController {
         }
     }
 
-    func presentShareSheet() {
-        screenState.presentShareSheet()
-    }
-
-    func dismissShareSheet() {
-        screenState.dismissShareSheet()
-    }
-
     func toggleArticleReadStatus(
         dependencies: AppDependencies,
         isPreviewMode: Bool

--- a/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ArticleScreenController {
+    var screenState: ArticleScreenState
+
+    init(previewScreenState: ArticleScreenState? = nil) {
+        self.screenState = previewScreenState ?? ArticleScreenState()
+    }
+
+    func load(articleID: UUID?, dependencies: AppDependencies) async {
+        screenState.beginLoading(articleID: articleID)
+
+        guard let articleID else {
+            return
+        }
+
+        guard let articleQueryService = dependencies.articleQueryService else {
+            screenState.applyLoadingFailure(
+                "Article query service is unavailable.",
+                articleID: articleID
+            )
+            return
+        }
+
+        do {
+            if let article = try articleQueryService.fetchReaderArticle(id: articleID) {
+                screenState.applyLoadedArticle(article)
+            } else {
+                screenState.applyArticleNotFound(articleID: articleID)
+            }
+        } catch {
+            dependencies.logger.error("Failed to load article by ID \(articleID): \(error)")
+            screenState.applyLoadingFailure(
+                error.localizedDescription,
+                articleID: articleID
+            )
+        }
+    }
+
+    func presentShareSheet() {
+        screenState.presentShareSheet()
+    }
+
+    func dismissShareSheet() {
+        screenState.dismissShareSheet()
+    }
+}

--- a/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
@@ -111,4 +111,12 @@ final class ArticleScreenController {
 
         screenState.applyArticleMutation(article.updating(isStarred: newIsStarred))
     }
+
+    func openArticleInAppBrowser(
+        dependencies: AppDependencies,
+        appState: AppState
+    ) {
+        guard let article = screenState.article else { return }
+        dependencies.openArticleInWebView(article, using: appState)
+    }
 }

--- a/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
@@ -83,4 +83,32 @@ final class ArticleScreenController {
 
         screenState.applyArticleMutation(article.updating(isRead: newIsRead))
     }
+
+    func toggleArticleStarredStatus(
+        dependencies: AppDependencies,
+        isPreviewMode: Bool
+    ) {
+        guard let article = screenState.article else { return }
+        let newIsStarred = article.isStarred == false
+
+        if isPreviewMode == false {
+            guard let articleStateService = dependencies.articleStateService else {
+                dependencies.logger.error("Article state service is unavailable for starred toggle action")
+                return
+            }
+
+            do {
+                _ = try articleStateService.toggleStarred(
+                    feedID: article.feedID,
+                    articleExternalID: article.articleExternalID,
+                    at: .now
+                )
+            } catch {
+                dependencies.logger.error("Failed to toggle article starred status: \(error)")
+                return
+            }
+        }
+
+        screenState.applyArticleMutation(article.updating(isStarred: newIsStarred))
+    }
 }

--- a/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenController.swift
@@ -47,4 +47,40 @@ final class ArticleScreenController {
     func dismissShareSheet() {
         screenState.dismissShareSheet()
     }
+
+    func toggleArticleReadStatus(
+        dependencies: AppDependencies,
+        isPreviewMode: Bool
+    ) {
+        guard let article = screenState.article else { return }
+        let newIsRead = article.isRead == false
+
+        if isPreviewMode == false {
+            guard let articleStateService = dependencies.articleStateService else {
+                dependencies.logger.error("Article state service is unavailable for read toggle action")
+                return
+            }
+
+            do {
+                if newIsRead {
+                    _ = try articleStateService.markAsRead(
+                        feedID: article.feedID,
+                        articleExternalID: article.articleExternalID,
+                        at: .now
+                    )
+                } else {
+                    _ = try articleStateService.markAsUnread(
+                        feedID: article.feedID,
+                        articleExternalID: article.articleExternalID,
+                        at: .now
+                    )
+                }
+            } catch {
+                dependencies.logger.error("Failed to toggle article read status: \(error)")
+                return
+            }
+        }
+
+        screenState.applyArticleMutation(article.updating(isRead: newIsRead))
+    }
 }

--- a/RSSReader/Views/ArticleScreen/ArticleScreenNavigationState.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenNavigationState.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+enum ArticleScreenNavigationState {
+    static func showsBackButton(
+        horizontalSizeClass: UserInterfaceSizeClass?,
+        articleSelection: UUID?
+    ) -> Bool {
+        horizontalSizeClass == .compact && articleSelection != nil
+    }
+
+    static func shouldNavigateBackOnDrag(
+        startLocationX: CGFloat,
+        translation: CGSize
+    ) -> Bool {
+        startLocationX <= 32
+            && translation.width >= 80
+            && abs(translation.height) <= 48
+    }
+}

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
@@ -26,23 +26,15 @@ enum ArticleScreenBodySource: Equatable {
 
 @MainActor
 struct ArticleScreenBodyContentState: Equatable {
-    let text: String?
+    let blocks: [ArticleScreenBodyBlock]
     let source: ArticleScreenBodySource
 
-    init(article: ReaderArticleDTO) {
-        if let summary = article.summary?.nilIfBlank {
-            self.text = summary
-            self.source = .summary
-        } else if let contentText = article.contentText?.nilIfBlank {
-            self.text = contentText
-            self.source = .contentText
-        } else if let contentHTML = article.contentHTML?.nilIfBlank {
-            self.text = contentHTML
-            self.source = .contentHTML
-        } else {
-            self.text = nil
-            self.source = .empty
-        }
+    init(
+        blocks: [ArticleScreenBodyBlock],
+        source: ArticleScreenBodySource
+    ) {
+        self.blocks = blocks
+        self.source = source
     }
 }
 
@@ -53,7 +45,7 @@ struct ArticleScreenContentState: Equatable {
 
     init(article: ReaderArticleDTO) {
         self.header = ArticleScreenHeaderState(article: article)
-        self.body = ArticleScreenBodyContentState(article: article)
+        self.body = ArticleScreenContentRenderer.renderBody(for: article)
     }
 }
 
@@ -157,6 +149,28 @@ enum ArticleScreenURLResolver {
         }
 
         return validatedExternalURL(from: articleURL)
+    }
+
+    static func resolveMediaURL(rawValue: String, baseURLString: String?) -> URL? {
+        if let validatedURL = validatedExternalURL(from: rawValue) {
+            return validatedURL
+        }
+
+        guard
+            let normalizedValue = rawValue.nilIfBlank,
+            let baseURLString,
+            let baseURL = validatedExternalURL(from: baseURLString),
+            let relativeURL = URL(string: normalizedValue, relativeTo: baseURL)?.absoluteURL,
+            let components = URLComponents(url: relativeURL, resolvingAgainstBaseURL: true),
+            let scheme = components.scheme?.lowercased(),
+            let host = components.host,
+            host.isEmpty == false,
+            ["http", "https"].contains(scheme)
+        else {
+            return nil
+        }
+
+        return relativeURL
     }
 
     private static func validatedExternalURL(from rawValue: String) -> URL? {

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
@@ -66,8 +66,8 @@ struct ArticleScreenHeaderState: Equatable {
 
 @MainActor
 struct ArticleScreenBottomActionsState: Equatable {
-    let markUnreadTitle: String
-    let markUnreadSystemImage: String
+    let readToggleTitle: String
+    let readToggleSystemImage: String
     let starTitle: String
     let starSystemImage: String
     let openInAppBrowserTitle: String
@@ -75,8 +75,8 @@ struct ArticleScreenBottomActionsState: Equatable {
     let canOpenInAppBrowser: Bool
 
     init(article: ReaderArticleDTO) {
-        self.markUnreadTitle = "Mark Unread"
-        self.markUnreadSystemImage = article.isRead ? "circle" : "circle.fill"
+        self.readToggleTitle = article.isRead ? "Mark Unread" : "Mark Read"
+        self.readToggleSystemImage = article.isRead ? "circle" : "circle.fill"
         self.starTitle = "Star"
         self.starSystemImage = article.isStarred ? "star.fill" : "star"
         self.openInAppBrowserTitle = "Open in App-Browser"

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+@MainActor
+enum ArticleScreenPhase: Equatable {
+    case noSelection
+    case loading
+    case loaded
+    case notFound
+    case failed(String)
+}
+
+@MainActor
+struct ArticleScreenPlaceholderState: Equatable {
+    let title: String
+    let systemImage: String
+    let description: String?
+}
+
+@MainActor
+enum ArticleScreenBodySource: Equatable {
+    case summary
+    case contentText
+    case contentHTML
+    case empty
+}
+
+@MainActor
+struct ArticleScreenBodyContentState: Equatable {
+    let text: String?
+    let source: ArticleScreenBodySource
+
+    init(article: ReaderArticleDTO) {
+        if let summary = article.summary?.nilIfBlank {
+            self.text = summary
+            self.source = .summary
+        } else if let contentText = article.contentText?.nilIfBlank {
+            self.text = contentText
+            self.source = .contentText
+        } else if let contentHTML = article.contentHTML?.nilIfBlank {
+            self.text = contentHTML
+            self.source = .contentHTML
+        } else {
+            self.text = nil
+            self.source = .empty
+        }
+    }
+}
+
+@MainActor
+struct ArticleScreenContentState: Equatable {
+    let title: String
+    let feedTitle: String
+    let author: String?
+    let publishedAtText: String?
+    let body: ArticleScreenBodyContentState
+
+    init(article: ReaderArticleDTO) {
+        self.title = article.title
+        self.feedTitle = article.feedTitle
+        self.author = article.author?.nilIfBlank
+        self.publishedAtText = article.publishedAt.map(ArticleScreenDateFormatter.string(from:))
+        self.body = ArticleScreenBodyContentState(article: article)
+    }
+}
+
+@MainActor
+struct ArticleScreenMenuActionsState: Equatable {
+    let starActionTitle: String
+    let starActionSystemImage: String
+    let readActionTitle: String
+    let readActionSystemImage: String
+    let canOpenInAppBrowser: Bool
+
+    init(article: ReaderArticleDTO) {
+        self.starActionTitle = article.isStarred ? "Unstar" : "Star"
+        self.starActionSystemImage = article.isStarred ? "star.slash" : "star"
+        self.readActionTitle = article.isRead ? "Mark Unread" : "Mark Read"
+        self.readActionSystemImage = article.isRead ? "envelope.badge" : "envelope.open"
+        self.canOpenInAppBrowser = ArticleScreenURLResolver.resolveExternalURL(
+            canonicalURL: article.canonicalURL,
+            articleURL: article.articleURL
+        ) != nil
+    }
+}
+
+@MainActor
+struct ArticleScreenToolbarActionsState: Equatable {
+    let showsShareAction: Bool
+    let showsMenuAction: Bool
+    let isShareEnabled: Bool
+    let isMenuEnabled: Bool
+    let menuActions: ArticleScreenMenuActionsState?
+
+    init(article: ReaderArticleDTO?) {
+        let hasArticle = article != nil
+        self.showsShareAction = hasArticle
+        self.showsMenuAction = hasArticle
+        self.isShareEnabled = article.flatMap(ArticleScreenShareSheetState.init(article:)) != nil
+        self.isMenuEnabled = hasArticle
+        self.menuActions = article.map(ArticleScreenMenuActionsState.init(article:))
+    }
+}
+
+@MainActor
+struct ArticleScreenShareSheetState: Equatable {
+    let articleID: UUID
+    let url: URL
+
+    init?(article: ReaderArticleDTO) {
+        guard let url = ArticleScreenURLResolver.resolveExternalURL(
+            canonicalURL: article.canonicalURL,
+            articleURL: article.articleURL
+        ) else {
+            return nil
+        }
+
+        self.articleID = article.id
+        self.url = url
+    }
+}
+
+@MainActor
+struct ArticleScreenDerivedViewState: Equatable {
+    let placeholder: ArticleScreenPlaceholderState?
+    let content: ArticleScreenContentState?
+    let toolbarActions: ArticleScreenToolbarActionsState
+}
+
+@MainActor
+enum ArticleScreenDateFormatter {
+    private static let formatter = Date.FormatStyle()
+        .weekday(.wide)
+        .day()
+        .month(.wide)
+        .year()
+        .hour()
+        .minute()
+
+    static func string(from date: Date) -> String {
+        date.formatted(formatter)
+    }
+}
+
+enum ArticleScreenURLResolver {
+    static func resolveExternalURL(canonicalURL: String?, articleURL: String) -> URL? {
+        if let canonicalURL, let resolvedCanonicalURL = validatedExternalURL(from: canonicalURL) {
+            return resolvedCanonicalURL
+        }
+
+        return validatedExternalURL(from: articleURL)
+    }
+
+    private static func validatedExternalURL(from rawValue: String) -> URL? {
+        guard
+            let normalizedValue = rawValue.nilIfBlank,
+            let components = URLComponents(string: normalizedValue),
+            let scheme = components.scheme?.lowercased(),
+            let host = components.host,
+            host.isEmpty == false,
+            ["http", "https"].contains(scheme),
+            let url = components.url
+        else {
+            return nil
+        }
+
+        return url
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let trimmedValue = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? nil : trimmedValue
+    }
+}

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
@@ -65,18 +65,22 @@ struct ArticleScreenHeaderState: Equatable {
 }
 
 @MainActor
-struct ArticleScreenMenuActionsState: Equatable {
-    let starActionTitle: String
-    let starActionSystemImage: String
-    let readActionTitle: String
-    let readActionSystemImage: String
+struct ArticleScreenBottomActionsState: Equatable {
+    let markUnreadTitle: String
+    let markUnreadSystemImage: String
+    let starTitle: String
+    let starSystemImage: String
+    let openInAppBrowserTitle: String
+    let openInAppBrowserSystemImage: String
     let canOpenInAppBrowser: Bool
 
     init(article: ReaderArticleDTO) {
-        self.starActionTitle = article.isStarred ? "Unstar" : "Star"
-        self.starActionSystemImage = article.isStarred ? "star.slash" : "star"
-        self.readActionTitle = article.isRead ? "Mark Unread" : "Mark Read"
-        self.readActionSystemImage = article.isRead ? "envelope.badge" : "envelope.open"
+        self.markUnreadTitle = "Mark Unread"
+        self.markUnreadSystemImage = article.isRead ? "circle" : "circle.fill"
+        self.starTitle = "Star"
+        self.starSystemImage = article.isStarred ? "star.fill" : "star"
+        self.openInAppBrowserTitle = "Open in App-Browser"
+        self.openInAppBrowserSystemImage = "safari"
         self.canOpenInAppBrowser = ArticleScreenURLResolver.resolveExternalURL(
             canonicalURL: article.canonicalURL,
             articleURL: article.articleURL
@@ -87,18 +91,16 @@ struct ArticleScreenMenuActionsState: Equatable {
 @MainActor
 struct ArticleScreenToolbarActionsState: Equatable {
     let showsShareAction: Bool
-    let showsMenuAction: Bool
+    let showsBottomActions: Bool
     let isShareEnabled: Bool
-    let isMenuEnabled: Bool
-    let menuActions: ArticleScreenMenuActionsState?
+    let bottomActions: ArticleScreenBottomActionsState?
 
     init(article: ReaderArticleDTO?) {
         let hasArticle = article != nil
         self.showsShareAction = hasArticle
-        self.showsMenuAction = hasArticle
+        self.showsBottomActions = hasArticle
         self.isShareEnabled = article.flatMap(ArticleScreenShareSheetState.init(article:)) != nil
-        self.isMenuEnabled = hasArticle
-        self.menuActions = article.map(ArticleScreenMenuActionsState.init(article:))
+        self.bottomActions = article.map(ArticleScreenBottomActionsState.init(article:))
     }
 }
 

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
@@ -48,18 +48,27 @@ struct ArticleScreenBodyContentState: Equatable {
 
 @MainActor
 struct ArticleScreenContentState: Equatable {
-    let title: String
-    let feedTitle: String
-    let author: String?
-    let publishedAtText: String?
+    let header: ArticleScreenHeaderState
     let body: ArticleScreenBodyContentState
 
     init(article: ReaderArticleDTO) {
-        self.title = article.title
-        self.feedTitle = article.feedTitle
-        self.author = article.author?.nilIfBlank
-        self.publishedAtText = article.publishedAt.map(ArticleScreenDateFormatter.string(from:))
+        self.header = ArticleScreenHeaderState(article: article)
         self.body = ArticleScreenBodyContentState(article: article)
+    }
+}
+
+@MainActor
+struct ArticleScreenHeaderState: Equatable {
+    let publishedAtText: String?
+    let title: String
+    let author: String?
+    let feedTitle: String?
+
+    init(article: ReaderArticleDTO) {
+        self.publishedAtText = article.publishedAt.map(ArticleScreenDateFormatter.string(from:))
+        self.title = article.title.nilIfBlank ?? "Untitled Article"
+        self.author = article.author?.nilIfBlank
+        self.feedTitle = article.feedTitle.nilIfBlank
     }
 }
 

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
@@ -21,13 +21,33 @@ enum ArticleScreenBodySource: Equatable {
     case summary
     case contentText
     case contentHTML
+    case fullTextExtracted
     case empty
+
+    var readerMode: ArticleScreenReaderMode {
+        switch self {
+        case .fullTextExtracted:
+            .fullText
+        case .summary, .contentText, .contentHTML, .empty:
+            .embedded
+        }
+    }
+}
+
+@MainActor
+enum ArticleScreenReaderMode: Equatable {
+    case embedded
+    case fullText
 }
 
 @MainActor
 struct ArticleScreenBodyContentState: Equatable {
     let blocks: [ArticleScreenBodyBlock]
     let source: ArticleScreenBodySource
+    
+    var readerMode: ArticleScreenReaderMode {
+        source.readerMode
+    }
 
     init(
         blocks: [ArticleScreenBodyBlock],
@@ -35,6 +55,13 @@ struct ArticleScreenBodyContentState: Equatable {
     ) {
         self.blocks = blocks
         self.source = source
+    }
+
+    static func extractedFullText(blocks: [ArticleScreenBodyBlock]) -> ArticleScreenBodyContentState {
+        ArticleScreenBodyContentState(
+            blocks: blocks,
+            source: .fullTextExtracted
+        )
     }
 }
 

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPresentationModels.swift
@@ -93,32 +93,17 @@ struct ArticleScreenToolbarActionsState: Equatable {
     let showsShareAction: Bool
     let showsBottomActions: Bool
     let isShareEnabled: Bool
+    let shareURL: URL?
     let bottomActions: ArticleScreenBottomActionsState?
 
     init(article: ReaderArticleDTO?) {
         let hasArticle = article != nil
+        let shareURL = article.flatMap(ArticleScreenShareURLResolver.resolveShareURL(article:))
         self.showsShareAction = hasArticle
         self.showsBottomActions = hasArticle
-        self.isShareEnabled = article.flatMap(ArticleScreenShareSheetState.init(article:)) != nil
+        self.isShareEnabled = shareURL != nil
+        self.shareURL = shareURL
         self.bottomActions = article.map(ArticleScreenBottomActionsState.init(article:))
-    }
-}
-
-@MainActor
-struct ArticleScreenShareSheetState: Equatable {
-    let articleID: UUID
-    let url: URL
-
-    init?(article: ReaderArticleDTO) {
-        guard let url = ArticleScreenURLResolver.resolveExternalURL(
-            canonicalURL: article.canonicalURL,
-            articleURL: article.articleURL
-        ) else {
-            return nil
-        }
-
-        self.articleID = article.id
-        self.url = url
     }
 }
 
@@ -141,6 +126,15 @@ enum ArticleScreenDateFormatter {
 
     static func string(from date: Date) -> String {
         date.formatted(formatter)
+    }
+}
+
+enum ArticleScreenShareURLResolver {
+    static func resolveShareURL(article: ReaderArticleDTO) -> URL? {
+        ArticleScreenURLResolver.resolveExternalURL(
+            canonicalURL: article.canonicalURL,
+            articleURL: article.articleURL
+        )
     }
 }
 

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPreviewData.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPreviewData.swift
@@ -50,6 +50,7 @@ private struct ArticleScreenPreviewContainer: View {
                 previewScreenState: screenState
             )
             .environment(\.appDependencies, AppDependencies.makeDefault())
+            .environment(AppState())
         }
     }
 }

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPreviewData.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPreviewData.swift
@@ -61,7 +61,8 @@ private enum ArticleScreenPreviewData {
             summary: """
             Утром 3 апреля был зафиксирован массовый сбой сразу в нескольких российских банках. Пользователи жаловались на переводы, оплату картой и вход в мобильные приложения.
             """,
-            contentText: nil
+            contentText: nil,
+            isRead: true
         )
     }
 
@@ -94,7 +95,8 @@ private enum ArticleScreenPreviewData {
     private static func makeArticle(
         title: String,
         summary: String?,
-        contentText: String?
+        contentText: String?,
+        isRead: Bool = false
     ) -> ReaderArticleDTO {
         ReaderArticleDTO(
             id: UUID(),
@@ -112,7 +114,7 @@ private enum ArticleScreenPreviewData {
             articleURL: "https://thecode.media/sber-vtb-tbank-failure",
             canonicalURL: "https://thecode.media/sber-vtb-tbank-failure",
             imageURL: nil,
-            isRead: false,
+            isRead: isRead,
             isStarred: false,
             isHidden: false
         )

--- a/RSSReader/Views/ArticleScreen/ArticleScreenPreviewData.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenPreviewData.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+#Preview("No Selection") {
+    ArticleScreenPreviewContainer(screenState: ArticleScreenState())
+}
+
+#Preview("Loading") {
+    ArticleScreenPreviewContainer(screenState: .previewLoading())
+}
+
+#Preview("Failed") {
+    ArticleScreenPreviewContainer(
+        screenState: .previewFailed(
+            message: "The selected article could not be loaded from persistence."
+        )
+    )
+}
+
+#Preview("Not Found") {
+    ArticleScreenPreviewContainer(screenState: .previewNotFound())
+}
+
+#Preview("Loaded Long Title") {
+    ArticleScreenPreviewContainer(
+        screenState: .previewLoaded(article: ArticleScreenPreviewData.longTitleArticle)
+    )
+}
+
+#Preview("Loaded Summary Body") {
+    ArticleScreenPreviewContainer(
+        screenState: .previewLoaded(article: ArticleScreenPreviewData.summaryBodyArticle)
+    )
+}
+
+#Preview("Loaded Content Text Body") {
+    ArticleScreenPreviewContainer(
+        screenState: .previewLoaded(article: ArticleScreenPreviewData.contentTextBodyArticle)
+    )
+}
+
+private struct ArticleScreenPreviewContainer: View {
+    let screenState: ArticleScreenState
+
+    var body: some View {
+        NavigationStack {
+            ReaderView(
+                articleID: nil,
+                showsBackButton: true,
+                navigateBackToArticles: {},
+                previewScreenState: screenState
+            )
+            .environment(\.appDependencies, AppDependencies.makeDefault())
+        }
+    }
+}
+
+private enum ArticleScreenPreviewData {
+    static var longTitleArticle: ReaderArticleDTO {
+        makeArticle(
+            title: "У Сбера, Т-Банка и ВТБ массовый сбой, который затронул платежи, переводы и часть операций в мобильных приложениях банков",
+            summary: """
+            Утром 3 апреля был зафиксирован массовый сбой сразу в нескольких российских банках. Пользователи жаловались на переводы, оплату картой и вход в мобильные приложения.
+            """,
+            contentText: nil
+        )
+    }
+
+    static var summaryBodyArticle: ReaderArticleDTO {
+        makeArticle(
+            title: "Короткий материал с summary как основным телом статьи",
+            summary: """
+            Это пример статьи, в которой feed отдал только summary или summary оказался самым качественным источником текста для embedded reader.
+
+            В таком случае `Article Screen` показывает именно summary, потому что сейчас rendering policy выбирает его первым.
+            """,
+            contentText: nil
+        )
+    }
+
+    static var contentTextBodyArticle: ReaderArticleDTO {
+        makeArticle(
+            title: "Материал с полным contentText в качестве основного текста",
+            summary: nil,
+            contentText: """
+            Это пример статьи, в которой feed отдал не только краткий анонс, а полноценный текст в поле contentText.
+
+            Для embedded reader это более предпочтительный источник, когда summary отсутствует.
+
+            Обычно такое приходит из `content:encoded`, `content` или другого более полного поля внутри XML feed.
+            """
+        )
+    }
+
+    private static func makeArticle(
+        title: String,
+        summary: String?,
+        contentText: String?
+    ) -> ReaderArticleDTO {
+        ReaderArticleDTO(
+            id: UUID(),
+            feedID: UUID(),
+            feedTitle: "THECODE.MEDIA",
+            feedSiteURL: "https://thecode.media",
+            articleExternalID: UUID().uuidString,
+            title: title,
+            summary: summary,
+            contentHTML: nil,
+            contentText: contentText,
+            author: "Юлия Зубарева",
+            publishedAt: Date(timeIntervalSince1970: 1_775_358_720),
+            updatedAtSource: nil,
+            articleURL: "https://thecode.media/sber-vtb-tbank-failure",
+            canonicalURL: "https://thecode.media/sber-vtb-tbank-failure",
+            imageURL: nil,
+            isRead: false,
+            isStarred: false,
+            isHidden: false
+        )
+    }
+}

--- a/RSSReader/Views/ArticleScreen/ArticleScreenState.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenState.swift
@@ -6,7 +6,6 @@ struct ArticleScreenState {
     private(set) var article: ReaderArticleDTO?
     private(set) var phase: ArticleScreenPhase = .noSelection
     private(set) var toolbarActions = ArticleScreenToolbarActionsState(article: nil)
-    var pendingShareSheet: ArticleScreenShareSheetState?
 
     var placeholder: ArticleScreenPlaceholderState? {
         switch phase {
@@ -47,7 +46,6 @@ struct ArticleScreenState {
 
     mutating func beginLoading(articleID: UUID?) {
         self.articleID = articleID
-        pendingShareSheet = nil
 
         guard articleID != nil else {
             article = nil
@@ -65,7 +63,6 @@ struct ArticleScreenState {
         articleID = article.id
         self.article = article
         phase = .loaded
-        pendingShareSheet = nil
         updateToolbarActions()
     }
 
@@ -82,7 +79,6 @@ struct ArticleScreenState {
         self.articleID = articleID
         article = nil
         phase = articleID == nil ? .noSelection : .notFound
-        pendingShareSheet = nil
         updateToolbarActions()
     }
 
@@ -90,16 +86,7 @@ struct ArticleScreenState {
         self.articleID = articleID
         article = nil
         phase = articleID == nil ? .noSelection : .failed(message)
-        pendingShareSheet = nil
         updateToolbarActions()
-    }
-
-    mutating func presentShareSheet() {
-        pendingShareSheet = article.flatMap(ArticleScreenShareSheetState.init(article:))
-    }
-
-    mutating func dismissShareSheet() {
-        pendingShareSheet = nil
     }
 
     func derivedViewState() -> ArticleScreenDerivedViewState {

--- a/RSSReader/Views/ArticleScreen/ArticleScreenState.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenState.swift
@@ -69,6 +69,15 @@ struct ArticleScreenState {
         updateToolbarActions()
     }
 
+    mutating func applyArticleMutation(_ article: ReaderArticleDTO) {
+        articleID = article.id
+        self.article = article
+        if phase != .loading && phase != .noSelection {
+            phase = .loaded
+        }
+        updateToolbarActions()
+    }
+
     mutating func applyArticleNotFound(articleID: UUID?) {
         self.articleID = articleID
         article = nil

--- a/RSSReader/Views/ArticleScreen/ArticleScreenState.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenState.swift
@@ -107,6 +107,27 @@ struct ArticleScreenState {
 }
 
 extension ArticleScreenState {
+    static func previewLoading(articleID: UUID = UUID()) -> ArticleScreenState {
+        var state = ArticleScreenState()
+        state.beginLoading(articleID: articleID)
+        return state
+    }
+
+    static func previewFailed(
+        articleID: UUID = UUID(),
+        message: String
+    ) -> ArticleScreenState {
+        var state = ArticleScreenState()
+        state.applyLoadingFailure(message, articleID: articleID)
+        return state
+    }
+
+    static func previewNotFound(articleID: UUID = UUID()) -> ArticleScreenState {
+        var state = ArticleScreenState()
+        state.applyArticleNotFound(articleID: articleID)
+        return state
+    }
+
     static func previewLoaded(article: ReaderArticleDTO) -> ArticleScreenState {
         var state = ArticleScreenState()
         state.applyLoadedArticle(article)

--- a/RSSReader/Views/ArticleScreen/ArticleScreenState.swift
+++ b/RSSReader/Views/ArticleScreen/ArticleScreenState.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+@MainActor
+struct ArticleScreenState {
+    private(set) var articleID: UUID?
+    private(set) var article: ReaderArticleDTO?
+    private(set) var phase: ArticleScreenPhase = .noSelection
+    private(set) var toolbarActions = ArticleScreenToolbarActionsState(article: nil)
+    var pendingShareSheet: ArticleScreenShareSheetState?
+
+    var placeholder: ArticleScreenPlaceholderState? {
+        switch phase {
+        case .noSelection:
+            ArticleScreenPlaceholderState(
+                title: "No Article Selected",
+                systemImage: "doc.text",
+                description: nil
+            )
+        case .loading, .loaded:
+            nil
+        case .notFound:
+            ArticleScreenPlaceholderState(
+                title: "Article Not Found",
+                systemImage: "doc.text.magnifyingglass",
+                description: "The selected article could not be loaded from persistence."
+            )
+        case .failed(let message):
+            ArticleScreenPlaceholderState(
+                title: "Failed to Load Article",
+                systemImage: "exclamationmark.triangle",
+                description: message
+            )
+        }
+    }
+
+    var showsPrimaryLoadingIndicator: Bool {
+        phase == .loading && article == nil
+    }
+
+    var primaryFailureMessage: String? {
+        guard case .failed(let message) = phase else {
+            return nil
+        }
+
+        return message
+    }
+
+    mutating func beginLoading(articleID: UUID?) {
+        self.articleID = articleID
+        pendingShareSheet = nil
+
+        guard articleID != nil else {
+            article = nil
+            phase = .noSelection
+            updateToolbarActions()
+            return
+        }
+
+        article = nil
+        phase = .loading
+        updateToolbarActions()
+    }
+
+    mutating func applyLoadedArticle(_ article: ReaderArticleDTO) {
+        articleID = article.id
+        self.article = article
+        phase = .loaded
+        pendingShareSheet = nil
+        updateToolbarActions()
+    }
+
+    mutating func applyArticleNotFound(articleID: UUID?) {
+        self.articleID = articleID
+        article = nil
+        phase = articleID == nil ? .noSelection : .notFound
+        pendingShareSheet = nil
+        updateToolbarActions()
+    }
+
+    mutating func applyLoadingFailure(_ message: String, articleID: UUID?) {
+        self.articleID = articleID
+        article = nil
+        phase = articleID == nil ? .noSelection : .failed(message)
+        pendingShareSheet = nil
+        updateToolbarActions()
+    }
+
+    mutating func presentShareSheet() {
+        pendingShareSheet = article.flatMap(ArticleScreenShareSheetState.init(article:))
+    }
+
+    mutating func dismissShareSheet() {
+        pendingShareSheet = nil
+    }
+
+    func derivedViewState() -> ArticleScreenDerivedViewState {
+        ArticleScreenDerivedViewState(
+            placeholder: placeholder,
+            content: article.map(ArticleScreenContentState.init(article:)),
+            toolbarActions: toolbarActions
+        )
+    }
+
+    private mutating func updateToolbarActions() {
+        toolbarActions = ArticleScreenToolbarActionsState(article: article)
+    }
+}
+
+extension ArticleScreenState {
+    static func previewLoaded(article: ReaderArticleDTO) -> ArticleScreenState {
+        var state = ArticleScreenState()
+        state.applyLoadedArticle(article)
+        return state
+    }
+}

--- a/RSSReader/Views/ArticleScreen/ReaderView.swift
+++ b/RSSReader/Views/ArticleScreen/ReaderView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ReaderView: View {
+    @Environment(AppState.self) private var appState
     @Environment(\.appDependencies) private var dependencies
     let articleID: UUID?
     let showsBackButton: Bool
@@ -161,7 +162,10 @@ struct ReaderView: View {
 
     @MainActor
     private func handleOpenInAppBrowserTap() {
-        dependencies.logger.info("Article screen open in app-browser button tapped before navigation wiring")
+        controller.openArticleInAppBrowser(
+            dependencies: dependencies,
+            appState: appState
+        )
     }
 
     @ViewBuilder

--- a/RSSReader/Views/ArticleScreen/ReaderView.swift
+++ b/RSSReader/Views/ArticleScreen/ReaderView.swift
@@ -5,7 +5,21 @@ struct ReaderView: View {
     let articleID: UUID?
     let showsBackButton: Bool
     let navigateBackToArticles: () -> Void
+    let previewScreenState: ArticleScreenState?
     @State private var controller = ArticleScreenController()
+
+    init(
+        articleID: UUID?,
+        showsBackButton: Bool,
+        navigateBackToArticles: @escaping () -> Void,
+        previewScreenState: ArticleScreenState? = nil
+    ) {
+        self.articleID = articleID
+        self.showsBackButton = showsBackButton
+        self.navigateBackToArticles = navigateBackToArticles
+        self.previewScreenState = previewScreenState
+        self._controller = State(initialValue: ArticleScreenController(previewScreenState: previewScreenState))
+    }
 
     var body: some View {
         let viewState = controller.screenState.derivedViewState()
@@ -14,16 +28,24 @@ struct ReaderView: View {
             if let content = viewState.content {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 12) {
-                        Text(content.title)
+                        if let publishedAtText = content.header.publishedAtText {
+                            Text(publishedAtText)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Text(content.header.title)
                             .font(.title2.weight(.semibold))
 
-                        Text(content.feedTitle)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-
-                        if let author = content.author {
+                        if let author = content.header.author {
                             Text(author)
                                 .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        if let feedTitle = content.header.feedTitle {
+                            Text(feedTitle)
+                                .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
 
@@ -58,6 +80,7 @@ struct ReaderView: View {
             }
         }
         .task(id: articleID) {
+            guard previewScreenState == nil else { return }
             await controller.load(articleID: articleID, dependencies: dependencies)
         }
         .simultaneousGesture(backNavigationGesture)
@@ -82,7 +105,8 @@ struct ReaderView: View {
     ReaderView(
         articleID: nil,
         showsBackButton: false,
-        navigateBackToArticles: {}
+        navigateBackToArticles: {},
+        previewScreenState: nil
     )
         .environment(\.appDependencies, AppDependencies.makeDefault())
 }

--- a/RSSReader/Views/ArticleScreen/ReaderView.swift
+++ b/RSSReader/Views/ArticleScreen/ReaderView.swift
@@ -77,6 +77,45 @@ struct ReaderView: View {
                     .accessibilityLabel("Back to Articles")
                 }
             }
+
+            if viewState.toolbarActions.showsShareAction {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: handleShareActionTap) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                    .disabled(viewState.toolbarActions.isShareEnabled == false)
+                    .accessibilityLabel("Share")
+                }
+            }
+
+            if viewState.toolbarActions.showsBottomActions,
+               let bottomActions = viewState.toolbarActions.bottomActions {
+                ToolbarItem(placement: .bottomBar) {
+                    Button(action: handleMarkUnreadActionTap) {
+                        Image(systemName: bottomActions.markUnreadSystemImage)
+                    }
+                    .accessibilityLabel(bottomActions.markUnreadTitle)
+                }
+
+                ToolbarSpacer(placement: .bottomBar)
+
+                ToolbarItem(placement: .bottomBar) {
+                    Button(action: handleStarActionTap) {
+                        Image(systemName: bottomActions.starSystemImage)
+                    }
+                    .accessibilityLabel(bottomActions.starTitle)
+                }
+
+                ToolbarSpacer(placement: .bottomBar)
+
+                ToolbarItem(placement: .bottomBar) {
+                    Button(action: handleOpenInAppBrowserTap) {
+                        Image(systemName: bottomActions.openInAppBrowserSystemImage)
+                    }
+                    .disabled(bottomActions.canOpenInAppBrowser == false)
+                    .accessibilityLabel(bottomActions.openInAppBrowserTitle)
+                }                
+            }
         }
         .task(id: articleID) {
             guard previewScreenState == nil else { return }
@@ -97,6 +136,26 @@ struct ReaderView: View {
                 }
                 navigateBackToArticles()
             }
+    }
+
+    @MainActor
+    private func handleShareActionTap() {
+        dependencies.logger.info("Article screen share button tapped before share flow wiring")
+    }
+
+    @MainActor
+    private func handleMarkUnreadActionTap() {
+        dependencies.logger.info("Article screen mark unread button tapped before action wiring")
+    }
+
+    @MainActor
+    private func handleStarActionTap() {
+        dependencies.logger.info("Article screen star button tapped before action wiring")
+    }
+
+    @MainActor
+    private func handleOpenInAppBrowserTap() {
+        dependencies.logger.info("Article screen open in app-browser button tapped before navigation wiring")
     }
 
     @ViewBuilder
@@ -140,14 +199,4 @@ struct ReaderView: View {
                 .padding(.top, 4)
         }
     }
-}
-
-#Preview {
-    ReaderView(
-        articleID: nil,
-        showsBackButton: false,
-        navigateBackToArticles: {},
-        previewScreenState: nil
-    )
-        .environment(\.appDependencies, AppDependencies.makeDefault())
 }

--- a/RSSReader/Views/ArticleScreen/ReaderView.swift
+++ b/RSSReader/Views/ArticleScreen/ReaderView.swift
@@ -49,9 +49,8 @@ struct ReaderView: View {
                                 .foregroundStyle(.secondary)
                         }
 
-                        if let bodyText = content.body.text {
-                            Text(bodyText)
-                                .font(.body)
+                        ForEach(Array(content.body.blocks.enumerated()), id: \.offset) { _, block in
+                            bodyBlockView(block)
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -98,6 +97,48 @@ struct ReaderView: View {
                 }
                 navigateBackToArticles()
             }
+    }
+
+    @ViewBuilder
+    private func bodyBlockView(_ block: ArticleScreenBodyBlock) -> some View {
+        switch block {
+        case .paragraph(let text):
+            Text(text)
+                .font(.body)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        case .image(let url):
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .empty:
+                    ZStack {
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(.quaternary.opacity(0.4))
+                        ProgressView()
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 220)
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxWidth: .infinity)
+                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                case .failure:
+                    ContentUnavailableView(
+                        "Image Unavailable",
+                        systemImage: "photo",
+                        description: Text("The article image could not be loaded.")
+                    )
+                @unknown default:
+                    EmptyView()
+                }
+            }
+        case .fallbackNotice(let message):
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .padding(.top, 4)
+        }
     }
 }
 

--- a/RSSReader/Views/ArticleScreen/ReaderView.swift
+++ b/RSSReader/Views/ArticleScreen/ReaderView.swift
@@ -81,11 +81,18 @@ struct ReaderView: View {
 
             if viewState.toolbarActions.showsShareAction {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button(action: handleShareActionTap) {
-                        Image(systemName: "square.and.arrow.up")
+                    if let shareURL = viewState.toolbarActions.shareURL {
+                        ShareLink(item: shareURL) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                        .accessibilityLabel("Share")
+                    } else {
+                        Button(action: {}) {
+                            Image(systemName: "square.and.arrow.up")
+                        }
+                        .disabled(true)
+                        .accessibilityLabel("Share")
                     }
-                    .disabled(viewState.toolbarActions.isShareEnabled == false)
-                    .accessibilityLabel("Share")
                 }
             }
 
@@ -137,11 +144,6 @@ struct ReaderView: View {
                 }
                 navigateBackToArticles()
             }
-    }
-
-    @MainActor
-    private func handleShareActionTap() {
-        dependencies.logger.info("Article screen share button tapped before share flow wiring")
     }
 
     @MainActor

--- a/RSSReader/Views/ArticleScreen/ReaderView.swift
+++ b/RSSReader/Views/ArticleScreen/ReaderView.swift
@@ -92,9 +92,9 @@ struct ReaderView: View {
                let bottomActions = viewState.toolbarActions.bottomActions {
                 ToolbarItem(placement: .bottomBar) {
                     Button(action: handleMarkUnreadActionTap) {
-                        Image(systemName: bottomActions.markUnreadSystemImage)
+                        Image(systemName: bottomActions.readToggleSystemImage)
                     }
-                    .accessibilityLabel(bottomActions.markUnreadTitle)
+                    .accessibilityLabel(bottomActions.readToggleTitle)
                 }
 
                 ToolbarSpacer(placement: .bottomBar)
@@ -145,7 +145,10 @@ struct ReaderView: View {
 
     @MainActor
     private func handleMarkUnreadActionTap() {
-        dependencies.logger.info("Article screen mark unread button tapped before action wiring")
+        controller.toggleArticleReadStatus(
+            dependencies: dependencies,
+            isPreviewMode: previewScreenState != nil
+        )
     }
 
     @MainActor

--- a/RSSReader/Views/ArticleScreen/ReaderView.swift
+++ b/RSSReader/Views/ArticleScreen/ReaderView.swift
@@ -153,7 +153,10 @@ struct ReaderView: View {
 
     @MainActor
     private func handleStarActionTap() {
-        dependencies.logger.info("Article screen star button tapped before action wiring")
+        controller.toggleArticleStarredStatus(
+            dependencies: dependencies,
+            isPreviewMode: previewScreenState != nil
+        )
     }
 
     @MainActor

--- a/RSSReader/Views/ReaderView.swift
+++ b/RSSReader/Views/ReaderView.swift
@@ -3,71 +3,49 @@ import SwiftUI
 struct ReaderView: View {
     @Environment(\.appDependencies) private var dependencies
     let articleID: UUID?
-    @State private var article: ReaderArticleDTO?
-    @State private var hasLoadedArticle = false
+    @State private var controller = ArticleScreenController()
 
     var body: some View {
+        let viewState = controller.screenState.derivedViewState()
+
         Group {
-            if let article {
+            if let content = viewState.content {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 12) {
-                        Text(article.title)
+                        Text(content.title)
                             .font(.title2.weight(.semibold))
 
-                        Text(article.feedTitle)
+                        Text(content.feedTitle)
                             .font(.caption)
                             .foregroundStyle(.secondary)
 
-                        if let author = article.author {
+                        if let author = content.author {
                             Text(author)
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         }
 
-                        if let summary = article.summary {
-                            Text(summary)
-                                .font(.body)
-                        } else if let contentText = article.contentText {
-                            Text(contentText)
-                                .font(.body)
-                        } else if let contentHTML = article.contentHTML {
-                            Text(contentHTML)
+                        if let bodyText = content.body.text {
+                            Text(bodyText)
                                 .font(.body)
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
                 }
-            } else if hasLoadedArticle, articleID != nil {
+            } else if controller.screenState.showsPrimaryLoadingIndicator {
+                ProgressView("Loading Article")
+            } else if let placeholder = viewState.placeholder {
                 ContentUnavailableView(
-                    "Article Not Found",
-                    systemImage: "doc.text.magnifyingglass",
-                    description: Text("The selected article could not be loaded from persistence.")
+                    placeholder.title,
+                    systemImage: placeholder.systemImage,
+                    description: placeholder.description.map(Text.init)
                 )
-            } else {
-                ContentUnavailableView("No Article Selected", systemImage: "doc.text")
             }
         }
         .navigationTitle("Reader")
         .task(id: articleID) {
-            await loadArticle()
-        }
-    }
-
-    @MainActor
-    private func loadArticle() async {
-        defer { hasLoadedArticle = true }
-
-        guard let articleID, let articleQueryService = dependencies.articleQueryService else {
-            article = nil
-            return
-        }
-
-        do {
-            article = try articleQueryService.fetchReaderArticle(id: articleID)
-        } catch {
-            dependencies.logger.error("Failed to load article by ID \(articleID): \(error)")
-            article = nil
+            await controller.load(articleID: articleID, dependencies: dependencies)
         }
     }
 }

--- a/RSSReader/Views/ReaderView.swift
+++ b/RSSReader/Views/ReaderView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ReaderView: View {
     @Environment(\.appDependencies) private var dependencies
     let articleID: UUID?
+    let showsBackButton: Bool
+    let navigateBackToArticles: () -> Void
     @State private var controller = ArticleScreenController()
 
     var body: some View {
@@ -43,14 +45,44 @@ struct ReaderView: View {
                 )
             }
         }
-        .navigationTitle("Reader")
+        .toolbarTitleDisplayMode(.inline)
+        .navigationTitle("")
+        .toolbar {
+            if showsBackButton {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: navigateBackToArticles) {
+                        Image(systemName: "chevron.left")
+                    }
+                    .accessibilityLabel("Back to Articles")
+                }
+            }
+        }
         .task(id: articleID) {
             await controller.load(articleID: articleID, dependencies: dependencies)
         }
+        .simultaneousGesture(backNavigationGesture)
+    }
+
+    private var backNavigationGesture: some Gesture {
+        DragGesture(minimumDistance: 20)
+            .onEnded { value in
+                guard showsBackButton else { return }
+                guard ArticleScreenNavigationState.shouldNavigateBackOnDrag(
+                    startLocationX: value.startLocation.x,
+                    translation: value.translation
+                ) else {
+                    return
+                }
+                navigateBackToArticles()
+            }
     }
 }
 
 #Preview {
-    ReaderView(articleID: nil)
+    ReaderView(
+        articleID: nil,
+        showsBackButton: false,
+        navigateBackToArticles: {}
+    )
         .environment(\.appDependencies, AppDependencies.makeDefault())
 }

--- a/RSSReader/Views/RootView.swift
+++ b/RSSReader/Views/RootView.swift
@@ -64,7 +64,14 @@ struct RootView: View {
                 selection: articleSelection
             )
         } detail: {
-            ReaderView(articleID: appState.selectedArticleID)
+            ReaderView(
+                articleID: appState.selectedArticleID,
+                showsBackButton: ArticleScreenNavigationState.showsBackButton(
+                    horizontalSizeClass: horizontalSizeClass,
+                    articleSelection: appState.selectedArticleID
+                ),
+                navigateBackToArticles: { appState.selectedArticleID = nil }
+            )
         }
         .onAppear(perform: syncPreferredCompactColumn)
         .onChange(of: appState.selectedSidebarSelection) { _, _ in

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1020,6 +1020,50 @@ struct RSSReaderTests {
     }
 
     @Test
+    func articleScreenNavigationStateShowsBackButtonOnlyForCompactArticleContext() {
+        #expect(
+            ArticleScreenNavigationState.showsBackButton(
+                horizontalSizeClass: .compact,
+                articleSelection: UUID()
+            )
+        )
+        #expect(
+            ArticleScreenNavigationState.showsBackButton(
+                horizontalSizeClass: .regular,
+                articleSelection: UUID()
+            ) == false
+        )
+        #expect(
+            ArticleScreenNavigationState.showsBackButton(
+                horizontalSizeClass: .compact,
+                articleSelection: nil
+            ) == false
+        )
+    }
+
+    @Test
+    func articleScreenNavigationStateRecognizesLeadingEdgeBackSwipe() {
+        #expect(
+            ArticleScreenNavigationState.shouldNavigateBackOnDrag(
+                startLocationX: 12,
+                translation: CGSize(width: 96, height: 8)
+            )
+        )
+        #expect(
+            ArticleScreenNavigationState.shouldNavigateBackOnDrag(
+                startLocationX: 80,
+                translation: CGSize(width: 96, height: 8)
+            ) == false
+        )
+        #expect(
+            ArticleScreenNavigationState.shouldNavigateBackOnDrag(
+                startLocationX: 12,
+                translation: CGSize(width: 40, height: 8)
+            ) == false
+        )
+    }
+
+    @Test
     func articlesScreenStateStartsWithoutSelectionPlaceholder() {
         let state = ArticlesScreenState()
 

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -940,7 +940,7 @@ struct RSSReaderTests {
         #expect(viewState.content?.header.title == article.title)
         #expect(viewState.content?.header.feedTitle == article.feedTitle)
         #expect(viewState.content?.header.author == article.author)
-        #expect(viewState.content?.body.text == "Rendered body text")
+        #expect(viewState.content?.body.blocks == [.paragraph("Rendered body text")])
         #expect(viewState.content?.body.source == .contentText)
         #expect(viewState.toolbarActions.showsShareAction)
         #expect(viewState.toolbarActions.isShareEnabled)
@@ -993,8 +993,74 @@ struct RSSReaderTests {
 
         state.applyLoadedArticle(article)
 
-        #expect(state.derivedViewState().content?.body.text == "Summary copy")
-        #expect(state.derivedViewState().content?.body.source == .summary)
+        #expect(state.derivedViewState().content?.body.blocks == [.paragraph("HTML body")])
+        #expect(state.derivedViewState().content?.body.source == .contentHTML)
+    }
+
+    @Test
+    func articleScreenContentRendererParsesHTMLParagraphsAndInlineImagesInOrder() {
+        let content = ArticleScreenContentState(
+            article: makeReaderArticleDTO(
+                summary: "Short summary",
+                contentHTML: """
+                <p>First paragraph.</p>
+                <img src="https://example.com/images/inline.png">
+                <p>Second <strong>paragraph</strong>.</p>
+                """,
+                contentText: "Plain text fallback"
+            )
+        )
+
+        #expect(
+            content.body.blocks == [
+                .paragraph("First paragraph."),
+                .image(URL(string: "https://example.com/images/inline.png")!),
+                .paragraph("Second paragraph.")
+            ]
+        )
+        #expect(content.body.source == .contentHTML)
+    }
+
+    @Test
+    func articleScreenContentRendererUsesSummaryWithFallbackNoticeWhenFullBodyIsUnavailable() {
+        let content = ArticleScreenContentState(
+            article: makeReaderArticleDTO(
+                summary: """
+                Short summary paragraph.
+
+                Another summary paragraph.
+                """,
+                contentHTML: nil,
+                contentText: nil
+            )
+        )
+
+        #expect(
+            content.body.blocks == [
+                .paragraph("Short summary paragraph."),
+                .paragraph("Another summary paragraph."),
+                .fallbackNotice("This source only provides a summary, not the full article body.")
+            ]
+        )
+        #expect(content.body.source == .summary)
+    }
+
+    @Test
+    func articleScreenContentRendererBuildsGracefulFallbackWhenFeedHasNoBodyContent() {
+        let content = ArticleScreenContentState(
+            article: makeReaderArticleDTO(
+                summary: nil,
+                contentHTML: nil,
+                contentText: nil
+            )
+        )
+
+        #expect(
+            content.body.blocks == [
+                .fallbackNotice("Full article content is unavailable in this feed.")
+            ]
+        )
+        #expect(content.body.source == .empty)
     }
 
     @Test

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -945,8 +945,8 @@ struct RSSReaderTests {
         #expect(viewState.toolbarActions.showsShareAction)
         #expect(viewState.toolbarActions.isShareEnabled)
         #expect(viewState.toolbarActions.showsBottomActions)
-        #expect(viewState.toolbarActions.bottomActions?.markUnreadTitle == "Mark Unread")
-        #expect(viewState.toolbarActions.bottomActions?.markUnreadSystemImage == "circle")
+        #expect(viewState.toolbarActions.bottomActions?.readToggleTitle == "Mark Unread")
+        #expect(viewState.toolbarActions.bottomActions?.readToggleSystemImage == "circle")
         #expect(viewState.toolbarActions.bottomActions?.starTitle == "Star")
         #expect(viewState.toolbarActions.bottomActions?.starSystemImage == "star.fill")
     }
@@ -1120,6 +1120,58 @@ struct RSSReaderTests {
 
         #expect(controller.screenState.phase == .notFound)
         #expect(controller.screenState.placeholder?.title == "Article Not Found")
+    }
+
+    @Test
+    func articleScreenControllerTogglesArticleReadStatusWithoutReloadingScreen() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/article-screen-mark-unread.xml"]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: "article-screen-mark-unread",
+            url: "https://example.com/articles/article-screen-mark-unread",
+            title: "Article Screen Mark Unread"
+        )
+        _ = try harness.articleStateService.markAsRead(
+            feedID: feed.id,
+            articleExternalID: article.externalID,
+            at: .now
+        )
+        let controller = ArticleScreenController()
+
+        await controller.load(articleID: article.id, dependencies: harness.dependencies)
+        controller.toggleArticleReadStatus(
+            dependencies: harness.dependencies,
+            isPreviewMode: false
+        )
+
+        var updatedArticle = try #require(controller.screenState.article)
+        #expect(updatedArticle.isRead == false)
+        #expect(controller.screenState.phase == .loaded)
+        #expect(controller.screenState.toolbarActions.bottomActions?.readToggleTitle == "Mark Read")
+        #expect(controller.screenState.toolbarActions.bottomActions?.readToggleSystemImage == "circle.fill")
+
+        var persistedState = try harness.articleStateRepository.fetchStateSnapshot(
+            feedID: feed.id,
+            articleExternalID: article.externalID
+        )
+        #expect(persistedState?.isRead == false)
+
+        controller.toggleArticleReadStatus(
+            dependencies: harness.dependencies,
+            isPreviewMode: false
+        )
+
+        updatedArticle = try #require(controller.screenState.article)
+        #expect(updatedArticle.isRead == true)
+        #expect(controller.screenState.toolbarActions.bottomActions?.readToggleTitle == "Mark Unread")
+        #expect(controller.screenState.toolbarActions.bottomActions?.readToggleSystemImage == "circle")
+
+        persistedState = try harness.articleStateRepository.fetchStateSnapshot(
+            feedID: feed.id,
+            articleExternalID: article.externalID
+        )
+        #expect(persistedState?.isRead == true)
     }
 
     @Test

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -942,6 +942,7 @@ struct RSSReaderTests {
         #expect(viewState.content?.header.author == article.author)
         #expect(viewState.content?.body.blocks == [.paragraph("Rendered body text")])
         #expect(viewState.content?.body.source == .contentText)
+        #expect(viewState.content?.body.readerMode == .embedded)
         #expect(viewState.toolbarActions.showsShareAction)
         #expect(viewState.toolbarActions.isShareEnabled)
         #expect(viewState.toolbarActions.showsBottomActions)
@@ -1064,6 +1065,20 @@ struct RSSReaderTests {
             ]
         )
         #expect(content.body.source == .empty)
+        #expect(content.body.readerMode == .embedded)
+    }
+
+    @Test
+    func articleScreenBodyContentStateDefinesFutureFullTextExtensionPoint() {
+        let extractedContent = ArticleScreenBodyContentState.extractedFullText(
+            blocks: [
+                .paragraph("Extracted full text paragraph.")
+            ]
+        )
+
+        #expect(extractedContent.source == .fullTextExtracted)
+        #expect(extractedContent.readerMode == .fullText)
+        #expect(extractedContent.blocks == [.paragraph("Extracted full text paragraph.")])
     }
 
     @Test

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1187,6 +1187,21 @@ struct RSSReaderTests {
     }
 
     @Test
+    func articleScreenControllerBuildsFailedPlaceholderWhenArticleQueryServiceIsUnavailable() async {
+        let dependencies = AppDependencies(logger: TestLogger())
+        let controller = ArticleScreenController()
+
+        await controller.load(articleID: UUID(), dependencies: dependencies)
+
+        #expect(controller.screenState.phase == .failed("Article query service is unavailable."))
+        #expect(controller.screenState.placeholder?.title == "Failed to Load Article")
+        #expect(
+            controller.screenState.placeholder?.description
+                == "Article query service is unavailable."
+        )
+    }
+
+    @Test
     func articleScreenControllerTogglesArticleReadStatusWithoutReloadingScreen() async throws {
         let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
         let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/article-screen-mark-unread.xml"]).first)

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1106,6 +1106,32 @@ struct RSSReaderTests {
     }
 
     @Test
+    func articleScreenBottomActionsEnableAppBrowserOnlyWhenArticleHasValidExternalURL() {
+        var loadedState = ArticleScreenState()
+        loadedState.applyLoadedArticle(
+            makeReaderArticleDTO(
+                canonicalURL: "https://example.com/articles/openable"
+            )
+        )
+
+        let loadedBottomActions = loadedState.derivedViewState().toolbarActions.bottomActions
+        #expect(loadedBottomActions?.openInAppBrowserTitle == "Open in App-Browser")
+        #expect(loadedBottomActions?.openInAppBrowserSystemImage == "safari")
+        #expect(loadedBottomActions?.canOpenInAppBrowser == true)
+
+        var invalidURLState = ArticleScreenState()
+        invalidURLState.applyLoadedArticle(
+            makeReaderArticleDTO(
+                articleURL: "invalid-url",
+                canonicalURL: nil
+            )
+        )
+
+        let invalidBottomActions = invalidURLState.derivedViewState().toolbarActions.bottomActions
+        #expect(invalidBottomActions?.canOpenInAppBrowser == false)
+    }
+
+    @Test
     func articleScreenControllerLoadsReaderArticleForCurrentSelection() async throws {
         let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
         let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/article-screen-load.xml"]).first)

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -920,7 +920,7 @@ struct RSSReaderTests {
         #expect(state.phase == .noSelection)
         #expect(state.placeholder?.title == "No Article Selected")
         #expect(state.toolbarActions.showsShareAction == false)
-        #expect(state.toolbarActions.showsMenuAction == false)
+        #expect(state.toolbarActions.showsBottomActions == false)
     }
 
     @Test
@@ -944,8 +944,11 @@ struct RSSReaderTests {
         #expect(viewState.content?.body.source == .contentText)
         #expect(viewState.toolbarActions.showsShareAction)
         #expect(viewState.toolbarActions.isShareEnabled)
-        #expect(viewState.toolbarActions.menuActions?.starActionTitle == "Unstar")
-        #expect(viewState.toolbarActions.menuActions?.readActionTitle == "Mark Unread")
+        #expect(viewState.toolbarActions.showsBottomActions)
+        #expect(viewState.toolbarActions.bottomActions?.markUnreadTitle == "Mark Unread")
+        #expect(viewState.toolbarActions.bottomActions?.markUnreadSystemImage == "circle")
+        #expect(viewState.toolbarActions.bottomActions?.starTitle == "Star")
+        #expect(viewState.toolbarActions.bottomActions?.starSystemImage == "star.fill")
     }
 
     @Test
@@ -1105,7 +1108,7 @@ struct RSSReaderTests {
 
         #expect(controller.screenState.phase == .loaded)
         #expect(controller.screenState.derivedViewState().content?.header.title == "Article Screen Load")
-        #expect(controller.screenState.toolbarActions.showsMenuAction)
+        #expect(controller.screenState.toolbarActions.showsBottomActions)
     }
 
     @Test

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1067,17 +1067,16 @@ struct RSSReaderTests {
     }
 
     @Test
-    func articleScreenStatePresentsShareSheetOnlyWhenArticleHasValidURL() {
+    func articleScreenToolbarActionsExposeShareURLOnlyWhenArticleHasValidURL() {
         var loadedState = ArticleScreenState()
         loadedState.applyLoadedArticle(
             makeReaderArticleDTO(
                 canonicalURL: "https://example.com/articles/shared"
             )
         )
-
-        loadedState.presentShareSheet()
-
-        #expect(loadedState.pendingShareSheet?.url.absoluteString == "https://example.com/articles/shared")
+        let loadedToolbarActions = loadedState.derivedViewState().toolbarActions
+        #expect(loadedToolbarActions.isShareEnabled)
+        #expect(loadedToolbarActions.shareURL?.absoluteString == "https://example.com/articles/shared")
 
         var invalidURLState = ArticleScreenState()
         invalidURLState.applyLoadedArticle(
@@ -1086,10 +1085,9 @@ struct RSSReaderTests {
                 canonicalURL: nil
             )
         )
-
-        invalidURLState.presentShareSheet()
-
-        #expect(invalidURLState.pendingShareSheet == nil)
+        let invalidToolbarActions = invalidURLState.derivedViewState().toolbarActions
+        #expect(invalidToolbarActions.isShareEnabled == false)
+        #expect(invalidToolbarActions.shareURL == nil)
     }
 
     @Test

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -914,6 +914,112 @@ struct RSSReaderTests {
     }
 
     @Test
+    func articleScreenStateStartsWithNoSelectionPlaceholder() {
+        let state = ArticleScreenState()
+
+        #expect(state.phase == .noSelection)
+        #expect(state.placeholder?.title == "No Article Selected")
+        #expect(state.toolbarActions.showsShareAction == false)
+        #expect(state.toolbarActions.showsMenuAction == false)
+    }
+
+    @Test
+    func articleScreenStateBuildsLoadedContentAndToolbarActions() {
+        var state = ArticleScreenState()
+        let article = makeReaderArticleDTO(
+            summary: nil,
+            contentText: "Rendered body text",
+            isRead: true,
+            isStarred: true
+        )
+
+        state.applyLoadedArticle(article)
+        let viewState = state.derivedViewState()
+
+        #expect(state.phase == .loaded)
+        #expect(viewState.content?.title == article.title)
+        #expect(viewState.content?.feedTitle == article.feedTitle)
+        #expect(viewState.content?.author == article.author)
+        #expect(viewState.content?.body.text == "Rendered body text")
+        #expect(viewState.content?.body.source == .contentText)
+        #expect(viewState.toolbarActions.showsShareAction)
+        #expect(viewState.toolbarActions.isShareEnabled)
+        #expect(viewState.toolbarActions.menuActions?.starActionTitle == "Unstar")
+        #expect(viewState.toolbarActions.menuActions?.readActionTitle == "Mark Unread")
+    }
+
+    @Test
+    func articleScreenStateUsesExistingRenderingPriorityForBodyContent() {
+        var state = ArticleScreenState()
+        let article = makeReaderArticleDTO(
+            summary: "Summary copy",
+            contentHTML: "<p>HTML body</p>",
+            contentText: "Longer content text"
+        )
+
+        state.applyLoadedArticle(article)
+
+        #expect(state.derivedViewState().content?.body.text == "Summary copy")
+        #expect(state.derivedViewState().content?.body.source == .summary)
+    }
+
+    @Test
+    func articleScreenStatePresentsShareSheetOnlyWhenArticleHasValidURL() {
+        var loadedState = ArticleScreenState()
+        loadedState.applyLoadedArticle(
+            makeReaderArticleDTO(
+                canonicalURL: "https://example.com/articles/shared"
+            )
+        )
+
+        loadedState.presentShareSheet()
+
+        #expect(loadedState.pendingShareSheet?.url.absoluteString == "https://example.com/articles/shared")
+
+        var invalidURLState = ArticleScreenState()
+        invalidURLState.applyLoadedArticle(
+            makeReaderArticleDTO(
+                articleURL: "not a valid url",
+                canonicalURL: nil
+            )
+        )
+
+        invalidURLState.presentShareSheet()
+
+        #expect(invalidURLState.pendingShareSheet == nil)
+    }
+
+    @Test
+    func articleScreenControllerLoadsReaderArticleForCurrentSelection() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/article-screen-load.xml"]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: "article-screen-load",
+            url: "https://example.com/articles/article-screen-load",
+            title: "Article Screen Load"
+        )
+        let controller = ArticleScreenController()
+
+        await controller.load(articleID: article.id, dependencies: harness.dependencies)
+
+        #expect(controller.screenState.phase == .loaded)
+        #expect(controller.screenState.derivedViewState().content?.title == "Article Screen Load")
+        #expect(controller.screenState.toolbarActions.showsMenuAction)
+    }
+
+    @Test
+    func articleScreenControllerBuildsNotFoundPlaceholderWhenArticleDoesNotExist() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let controller = ArticleScreenController()
+
+        await controller.load(articleID: UUID(), dependencies: harness.dependencies)
+
+        #expect(controller.screenState.phase == .notFound)
+        #expect(controller.screenState.placeholder?.title == "Article Not Found")
+    }
+
+    @Test
     func articlesScreenStateStartsWithoutSelectionPlaceholder() {
         let state = ArticlesScreenState()
 
@@ -2502,6 +2608,48 @@ private func makeArticleListItemDTO(
         isRead: isRead,
         isStarred: isStarred,
         isHidden: false
+    )
+}
+
+@MainActor
+private func makeReaderArticleDTO(
+    id: UUID = UUID(),
+    feedID: UUID = UUID(),
+    feedTitle: String = "Feed",
+    feedSiteURL: String? = "https://example.com",
+    articleExternalID: String = "article",
+    title: String = "Article",
+    summary: String? = "Summary",
+    contentHTML: String? = nil,
+    contentText: String? = nil,
+    author: String? = "Author",
+    publishedAt: Date? = nil,
+    articleURL: String = "https://example.com/articles/1",
+    canonicalURL: String? = "https://example.com/articles/1/canonical",
+    imageURL: String? = nil,
+    isRead: Bool = false,
+    isStarred: Bool = false,
+    isHidden: Bool = false
+) -> ReaderArticleDTO {
+    ReaderArticleDTO(
+        id: id,
+        feedID: feedID,
+        feedTitle: feedTitle,
+        feedSiteURL: feedSiteURL,
+        articleExternalID: articleExternalID,
+        title: title,
+        summary: summary,
+        contentHTML: contentHTML,
+        contentText: contentText,
+        author: author,
+        publishedAt: publishedAt,
+        updatedAtSource: nil,
+        articleURL: articleURL,
+        canonicalURL: canonicalURL,
+        imageURL: imageURL,
+        isRead: isRead,
+        isStarred: isStarred,
+        isHidden: isHidden
     )
 }
 

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1110,6 +1110,72 @@ struct RSSReaderTests {
     }
 
     @Test
+    func articleScreenControllerMarksArticleAsReadOnOpenWhenSettingIsEnabled() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appSettingsRepository = try #require(harness.dependencies.appSettingsRepository)
+        _ = try appSettingsRepository.update(
+            AppSettingsUpdate(
+                markAsReadOnOpen: true,
+                updatedAt: .distantPast
+            )
+        )
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/article-screen-mark-on-open.xml"]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: "article-screen-mark-on-open",
+            url: "https://example.com/articles/article-screen-mark-on-open",
+            title: "Article Screen Mark On Open"
+        )
+        let controller = ArticleScreenController()
+
+        await controller.load(articleID: article.id, dependencies: harness.dependencies)
+
+        let loadedArticle = try #require(controller.screenState.article)
+        #expect(loadedArticle.isRead == true)
+        #expect(controller.screenState.toolbarActions.bottomActions?.readToggleTitle == "Mark Unread")
+        #expect(controller.screenState.toolbarActions.bottomActions?.readToggleSystemImage == "circle")
+
+        let persistedState = try harness.articleStateRepository.fetchStateSnapshot(
+            feedID: feed.id,
+            articleExternalID: article.externalID
+        )
+        #expect(persistedState?.isRead == true)
+    }
+
+    @Test
+    func articleScreenControllerKeepsArticleUnreadOnOpenWhenSettingIsDisabled() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appSettingsRepository = try #require(harness.dependencies.appSettingsRepository)
+        _ = try appSettingsRepository.update(
+            AppSettingsUpdate(
+                markAsReadOnOpen: false,
+                updatedAt: .distantPast
+            )
+        )
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/article-screen-keep-unread-on-open.xml"]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: "article-screen-keep-unread-on-open",
+            url: "https://example.com/articles/article-screen-keep-unread-on-open",
+            title: "Article Screen Keep Unread On Open"
+        )
+        let controller = ArticleScreenController()
+
+        await controller.load(articleID: article.id, dependencies: harness.dependencies)
+
+        let loadedArticle = try #require(controller.screenState.article)
+        #expect(loadedArticle.isRead == false)
+        #expect(controller.screenState.toolbarActions.bottomActions?.readToggleTitle == "Mark Read")
+        #expect(controller.screenState.toolbarActions.bottomActions?.readToggleSystemImage == "circle.fill")
+
+        let persistedState = try harness.articleStateRepository.fetchStateSnapshot(
+            feedID: feed.id,
+            articleExternalID: article.externalID
+        )
+        #expect(persistedState == nil)
+    }
+
+    @Test
     func articleScreenControllerBuildsNotFoundPlaceholderWhenArticleDoesNotExist() async throws {
         let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
         let controller = ArticleScreenController()

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1220,6 +1220,43 @@ struct RSSReaderTests {
     }
 
     @Test
+    func articleScreenControllerOpensCurrentArticleInAppLevelWebViewRoute() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appState = AppState()
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/article-screen-open-web.xml"]).first)
+        let articleModel = try harness.insertArticle(
+            feed: feed,
+            externalID: "article-screen-open-web",
+            url: "https://example.com/articles/article-screen-open-web",
+            title: "Article Screen Open Web"
+        )
+        articleModel.canonicalURL = "https://example.com/articles/article-screen-open-web/canonical"
+        try harness.saveModelContext()
+        let controller = ArticleScreenController()
+
+        await controller.load(articleID: articleModel.id, dependencies: harness.dependencies)
+        controller.openArticleInAppBrowser(
+            dependencies: harness.dependencies,
+            appState: appState
+        )
+
+        #expect(
+            appState.selectedDetailRoute == .webView(
+                ArticleWebViewRoute(
+                    articleID: articleModel.id,
+                    url: URL(string: "https://example.com/articles/article-screen-open-web/canonical")!
+                )
+            )
+        )
+        #expect(
+            appState.presentedWebViewRoute == ArticleWebViewRoute(
+                articleID: articleModel.id,
+                url: URL(string: "https://example.com/articles/article-screen-open-web/canonical")!
+            )
+        )
+    }
+
+    @Test
     func articleScreenNavigationStateShowsBackButtonOnlyForCompactArticleContext() {
         #expect(
             ArticleScreenNavigationState.showsBackButton(

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -937,15 +937,49 @@ struct RSSReaderTests {
         let viewState = state.derivedViewState()
 
         #expect(state.phase == .loaded)
-        #expect(viewState.content?.title == article.title)
-        #expect(viewState.content?.feedTitle == article.feedTitle)
-        #expect(viewState.content?.author == article.author)
+        #expect(viewState.content?.header.title == article.title)
+        #expect(viewState.content?.header.feedTitle == article.feedTitle)
+        #expect(viewState.content?.header.author == article.author)
         #expect(viewState.content?.body.text == "Rendered body text")
         #expect(viewState.content?.body.source == .contentText)
         #expect(viewState.toolbarActions.showsShareAction)
         #expect(viewState.toolbarActions.isShareEnabled)
         #expect(viewState.toolbarActions.menuActions?.starActionTitle == "Unstar")
         #expect(viewState.toolbarActions.menuActions?.readActionTitle == "Mark Unread")
+    }
+
+    @Test
+    func articleScreenContentHeaderFormatsFieldsInPublishedTitleAuthorFeedOrder() {
+        let publishedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let content = ArticleScreenContentState(
+            article: makeReaderArticleDTO(
+                feedTitle: "THECODE.MEDIA",
+                author: "Юлия Зубарева",
+                publishedAt: publishedAt
+            )
+        )
+
+        #expect(content.header.publishedAtText == ArticleScreenDateFormatter.string(from: publishedAt))
+        #expect(content.header.title == "Article")
+        #expect(content.header.author == "Юлия Зубарева")
+        #expect(content.header.feedTitle == "THECODE.MEDIA")
+    }
+
+    @Test
+    func articleScreenContentHeaderHidesBlankMetadataAndFallsBackForBlankTitle() {
+        let content = ArticleScreenContentState(
+            article: makeReaderArticleDTO(
+                feedTitle: "   ",
+                title: "   ",
+                author: " \n ",
+                publishedAt: nil
+            )
+        )
+
+        #expect(content.header.publishedAtText == nil)
+        #expect(content.header.title == "Untitled Article")
+        #expect(content.header.author == nil)
+        #expect(content.header.feedTitle == nil)
     }
 
     @Test
@@ -1004,7 +1038,7 @@ struct RSSReaderTests {
         await controller.load(articleID: article.id, dependencies: harness.dependencies)
 
         #expect(controller.screenState.phase == .loaded)
-        #expect(controller.screenState.derivedViewState().content?.title == "Article Screen Load")
+        #expect(controller.screenState.derivedViewState().content?.header.title == "Article Screen Load")
         #expect(controller.screenState.toolbarActions.showsMenuAction)
     }
 

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1175,6 +1175,51 @@ struct RSSReaderTests {
     }
 
     @Test
+    func articleScreenControllerTogglesArticleStarredStatusWithoutReloadingScreen() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/article-screen-toggle-star.xml"]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: "article-screen-toggle-star",
+            url: "https://example.com/articles/article-screen-toggle-star",
+            title: "Article Screen Toggle Star"
+        )
+        let controller = ArticleScreenController()
+
+        await controller.load(articleID: article.id, dependencies: harness.dependencies)
+        controller.toggleArticleStarredStatus(
+            dependencies: harness.dependencies,
+            isPreviewMode: false
+        )
+
+        var updatedArticle = try #require(controller.screenState.article)
+        #expect(updatedArticle.isStarred == true)
+        #expect(controller.screenState.phase == .loaded)
+        #expect(controller.screenState.toolbarActions.bottomActions?.starSystemImage == "star.fill")
+
+        var persistedState = try harness.articleStateRepository.fetchStateSnapshot(
+            feedID: feed.id,
+            articleExternalID: article.externalID
+        )
+        #expect(persistedState?.isStarred == true)
+
+        controller.toggleArticleStarredStatus(
+            dependencies: harness.dependencies,
+            isPreviewMode: false
+        )
+
+        updatedArticle = try #require(controller.screenState.article)
+        #expect(updatedArticle.isStarred == false)
+        #expect(controller.screenState.toolbarActions.bottomActions?.starSystemImage == "star")
+
+        persistedState = try harness.articleStateRepository.fetchStateSnapshot(
+            feedID: feed.id,
+            articleExternalID: article.externalID
+        )
+        #expect(persistedState?.isStarred == false)
+    }
+
+    @Test
     func articleScreenNavigationStateShowsBackButtonOnlyForCompactArticleContext() {
         #expect(
             ArticleScreenNavigationState.showsBackButton(


### PR DESCRIPTION
## Кратко
Задача Article Screen выполнена

Реализовано:
- [x] определить screen-level state/model для `Article Screen`, чтобы отделить загрузку статьи, toolbar actions, menu state, `share`, error/empty состояния и rendering policy от `ReaderView`;
- [x] определить compact navigation flow экрана: toolbar с back button слева, без отдельного title в navigation bar, возврат на `Articles Screen` по кнопке и системному back behavior;
- [x] оформить header контента в порядке `publishedAt` / `title` / `author` / `feedTitle`, включая правила скрытия пустых полей и единый formatter для даты и времени публикации;
- [x] улучшить content rendering pipeline: выбрать лучший доступный источник между `contentHTML`, `contentText`, `summary`, поддержать многоабзацный текст, inline images и аккуратный fallback для статей без полного тела;
- [x] добавить `share` в правую часть top bar и нижние actions `mark unread`, `star`, `open in app-browser` как три раздельные bottom bar кнопки;
- [x] связать нажатие на read toggle кнопку с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать `read` status статьи в обе стороны с иконкой `circle` / `circle.fill`;
- [x] связать нажатие на кнопку `star` с `ArticleStateService`, обновлять screen state без повторной загрузки экрана и переключать иконку `star` / `star.fill` по текущему `starred` status статьи;
- [x] связать нажатие на кнопку `open in app-browser` с app-level navigation entry point, чтобы `Article Screen` открывал `WebView Screen` через app-level routing без прямого знания о shell-роутинге;
- [x] связать нажатие на кнопку `share` с системным share sheet, использовать canonical article URL с корректным fallback на `articleURL`;
- [x] реализовать `markAsReadOnOpen` на основе `AppSettings` с явной policy: статья помечается read при открытии detail screen, но это не должно ломать ручное действие `mark unread`;
- [x] определить и реализовать loading / not found / rendering failure UX для `Article Screen`, а не только happy path с уже загруженной статьёй;
- [x] подготовить extension point под future full text flow: зафиксировать, где будет жить логика `full text` extraction, как она влияет на `ReaderArticleDTO`/presentation model и чем базовый embedded reader отличается от отдельного reader mode;
- [x] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, bottom actions и переход в `WebView Screen`.

## Закрывает
Closes #126 
Closes #127 
Closes #129 
Closes #130 
Closes #295 
Closes #296 
Closes #297 
Closes #298 
Closes #299 
Closes #300 
Closes #301 
Closes #302 
Closes #303 
Closes #125 