### PR TITLE
WebView Screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@
 - [x] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
 - [x] добавить нижний action `open in external browser` в `bottomBar`;
 - [x] реализовать left​-edge swipe to close и зарезервировать левый edge gesture за закрытием экрана, отключив конфликтующий history navigation внутри ​WKWeb​View;
-- [ ] добавить command bridge между `WebViewScreenController` и `WKWebView`, чтобы screen-level actions (`reload`, gesture refresh) не требовали хранить imperative web view state внутри SwiftUI `View`;
+- [x] добавить command bridge между `WebViewScreenController` и `WKWebView`, чтобы screen-level actions (`reload`, gesture refresh) не требовали хранить imperative web view state внутри SwiftUI `View`;
 - [ ] реализовать pull​-to​-refresh и определить, как он работает только в верхней точке scroll без конфликта с обычной прокруткой страницы;
 - [ ] синхронизировать `WebView Screen` с текущим page URL после navigation/redirects, чтобы `pull-to-refresh` и gesture-driven actions работали с актуальной открытой страницей, а не только с исходным `ArticleWebViewRoute.url`;
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@
 - [x] добавить нижний action `refresh` в левой части `bottomBar` и связать его с перезагрузкой текущей страницы в `WKWebView` без возврата к общему `command bridge`;
 - [x] синхронизировать `current page URL` с `WebView Screen` state, чтобы `share` и `open in external browser` использовали фактический адрес текущей открытой страницы, а не только исходный `ArticleWebViewRoute.url`;
 - [x] привести loading presentation `WebView Screen` к тому же UI pattern, что и у `Article Screen`, чтобы первичная загрузка выглядела консистентно на уровне приложения;
-- [ ] скрывать browser actions (`share`, `refresh`, `open in external browser`) в loading/error состояниях `WebView Screen`, чтобы toolbar и `bottomBar` не предлагали действия над ещё не открытой или недоступной страницей;
+- [x] скрывать browser actions (`share`, `refresh`, `open in external browser`) в loading/error состояниях `WebView Screen`, чтобы toolbar и `bottomBar` не предлагали действия над ещё не открытой или недоступной страницей;
 - [ ] провести `cleanup` `WebViewScreenView`: выделить секции/подвью, добавить `MARK` и упростить чтение `WKWebView` bridge-слоя без изменения поведения экрана.
 
 #### Settings Integration

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@
 - [x] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
 - [x] добавить нижний action `open in external browser` в `bottomBar`;
 - [x] реализовать единственный кастомный gesture `left-edge swipe to close`: edge swipe от левого края закрывает `WebView Screen` и возвращает пользователя в `Article Screen`, а встроенный history navigation внутри `WKWebView` отключён, чтобы жест не конфликтовал с поведением страницы;
+- [x] добавить нижний action `refresh` в левой части `bottomBar` и связать его с перезагрузкой текущей страницы в `WKWebView` без возврата к общему `command bridge`;
 
 #### Settings Integration
 - [ ] создать `SettingsViewModel`;

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@
 - [x] синхронизировать `current page URL` с `WebView Screen` state, чтобы `share` и `open in external browser` использовали фактический адрес текущей открытой страницы, а не только исходный `ArticleWebViewRoute.url`;
 - [x] привести loading presentation `WebView Screen` к тому же UI pattern, что и у `Article Screen`, чтобы первичная загрузка выглядела консистентно на уровне приложения;
 - [x] скрывать browser actions (`share`, `refresh`, `open in external browser`) в loading/error состояниях `WebView Screen`, чтобы toolbar и `bottomBar` не предлагали действия над ещё не открытой или недоступной страницей;
-- [ ] провести `cleanup` `WebViewScreenView`: выделить секции/подвью, добавить `MARK` и упростить чтение `WKWebView` bridge-слоя без изменения поведения экрана.
+- [x] провести `cleanup` `WebViewScreenView`: выделить секции/подвью, добавить `MARK` и упростить чтение `WKWebView` bridge-слоя без изменения поведения экрана.
 
 #### Settings Integration
 - [ ] создать `SettingsViewModel`;

--- a/README.md
+++ b/README.md
@@ -239,11 +239,18 @@
 - [x] добавить unit tests на screen-level state и action reducer для `Article Screen`, включая `markAsReadOnOpen`, bottom actions и переход в `WebView Screen`.
 
 #### WebView Screen
-- [ ] создать отдельный экран WebView для `articleURL`;
-- [ ] поддержать `defaultReaderMode` из `AppSettings`;
-- [ ] добавить loading state для web content;
-- [ ] добавить error/fallback UX, если `articleURL` не открывается;
-- [ ] добавить action открытия во внешнем браузере.
+- [x] определить app-level navigation flow для `WebView Screen`: `RootView` должен уметь переключать detail между `Article Screen` и `WebView Screen` по `ReadingDetailRoute.webView`, а закрытие web view должно возвращать пользователя к текущей статье;
+- [ ] создать отдельный `WebView Screen` на базе `WKWebView` для `articleURL`, чтобы экран получал уже подготовленный `ArticleWebViewRoute` и не знал о shell-роутинге напрямую;
+- [ ] определить screen-level state/model для `WebView Screen`, чтобы отделить `initialURL`, loading progress, navigation title, share action availability и error state от SwiftUI `View`;
+- [ ] реализовать загрузку `articleURL` в `WKWebView` с базовым loading state для первого открытия страницы;
+- [ ] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;
+- [ ] добавить toolbar-кнопку закрытия экрана в левой части top bar и связать её с app-level dismiss flow обратно в `Article Screen`;
+- [ ] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;
+- [ ] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
+- [ ] добавить unit tests на app-level routing и screen-level state `WebView Screen`: открытие по `ArticleWebViewRoute`, закрытие обратно в `Article Screen`, loading/error transitions и availability `share`.
+- [ ] исследовать и определить policy для дополнительных browser actions: `open in external browser`, `reload`, page settings / reader controls / translation menu;
+- [ ] добавить нижние actions `open in external browser` и `reload`, если они не конфликтуют с системным UX и компоновкой экрана;
+- [ ] определить, можно ли и нужно ли добавлять отдельную кнопку page settings / reader controls поверх `WKWebView`, или такие возможности должны оставаться системной ответственностью Safari / Reader mode.
 
 #### Settings Integration
 - [ ] создать `SettingsViewModel`;

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@
 - [x] реализовать загрузку `articleURL` в `WKWebView` с базовым loading state для первого открытия страницы;
 - [x] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;
 - [x] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;
-- [ ] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
+- [x] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
 - [ ] добавить unit tests на app-level routing и screen-level state `WebView Screen`: открытие по `ArticleWebViewRoute`, закрытие обратно в `Article Screen`, loading/error transitions и availability `share`.
 - [ ] исследовать и определить policy для дополнительных browser actions: `open in external browser`, `reload`, page settings / reader controls / translation menu;
 - [ ] добавить нижние actions `open in external browser` и `reload`, если они не конфликтуют с системным UX и компоновкой экрана;

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@
 - [x] создать отдельный `WebView Screen` на базе `WKWebView` для `articleURL`, чтобы экран получал уже подготовленный `ArticleWebViewRoute` и не знал о shell-роутинге напрямую;
 - [x] определить screen-level state/model для `WebView Screen`, чтобы отделить `initialURL`, loading progress, navigation title, share action availability и error state от SwiftUI `View`;
 - [x] реализовать загрузку `articleURL` в `WKWebView` с базовым loading state для первого открытия страницы;
-- [ ] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;
+- [x] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;
 - [ ] добавить toolbar-кнопку закрытия экрана в левой части top bar и связать её с app-level dismiss flow обратно в `Article Screen`;
 - [ ] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;
 - [ ] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@
 #### WebView Screen
 - [x] определить app-level navigation flow для `WebView Screen`: `RootView` должен уметь переключать detail между `Article Screen` и `WebView Screen` по `ReadingDetailRoute.webView`, а закрытие web view должно возвращать пользователя к текущей статье;
 - [x] создать отдельный `WebView Screen` на базе `WKWebView` для `articleURL`, чтобы экран получал уже подготовленный `ArticleWebViewRoute` и не знал о shell-роутинге напрямую;
-- [ ] определить screen-level state/model для `WebView Screen`, чтобы отделить `initialURL`, loading progress, navigation title, share action availability и error state от SwiftUI `View`;
+- [x] определить screen-level state/model для `WebView Screen`, чтобы отделить `initialURL`, loading progress, navigation title, share action availability и error state от SwiftUI `View`;
 - [ ] реализовать загрузку `articleURL` в `WKWebView` с базовым loading state для первого открытия страницы;
 - [ ] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;
 - [ ] добавить toolbar-кнопку закрытия экрана в левой части top bar и связать её с app-level dismiss flow обратно в `Article Screen`;

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@
 
 #### WebView Screen
 - [x] определить app-level navigation flow для `WebView Screen`: `RootView` должен уметь переключать detail между `Article Screen` и `WebView Screen` по `ReadingDetailRoute.webView`, а закрытие web view должно возвращать пользователя к текущей статье;
-- [ ] создать отдельный `WebView Screen` на базе `WKWebView` для `articleURL`, чтобы экран получал уже подготовленный `ArticleWebViewRoute` и не знал о shell-роутинге напрямую;
+- [x] создать отдельный `WebView Screen` на базе `WKWebView` для `articleURL`, чтобы экран получал уже подготовленный `ArticleWebViewRoute` и не знал о shell-роутинге напрямую;
 - [ ] определить screen-level state/model для `WebView Screen`, чтобы отделить `initialURL`, loading progress, navigation title, share action availability и error state от SwiftUI `View`;
 - [ ] реализовать загрузку `articleURL` в `WKWebView` с базовым loading state для первого открытия страницы;
 - [ ] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@
 - [x] реализовать единственный кастомный gesture `left-edge swipe to close`: edge swipe от левого края закрывает `WebView Screen` и возвращает пользователя в `Article Screen`, а встроенный history navigation внутри `WKWebView` отключён, чтобы жест не конфликтовал с поведением страницы;
 - [x] добавить нижний action `refresh` в левой части `bottomBar` и связать его с перезагрузкой текущей страницы в `WKWebView` без возврата к общему `command bridge`;
 - [x] синхронизировать `current page URL` с `WebView Screen` state, чтобы `share` и `open in external browser` использовали фактический адрес текущей открытой страницы, а не только исходный `ArticleWebViewRoute.url`;
-- [ ] привести loading presentation `WebView Screen` к тому же UI pattern, что и у `Article Screen`, чтобы первичная загрузка выглядела консистентно на уровне приложения;
+- [x] привести loading presentation `WebView Screen` к тому же UI pattern, что и у `Article Screen`, чтобы первичная загрузка выглядела консистентно на уровне приложения;
 - [ ] скрывать browser actions (`share`, `refresh`, `open in external browser`) в loading/error состояниях `WebView Screen`, чтобы toolbar и `bottomBar` не предлагали действия над ещё не открытой или недоступной страницей;
 - [ ] провести `cleanup` `WebViewScreenView`: выделить секции/подвью, добавить `MARK` и упростить чтение `WKWebView` bridge-слоя без изменения поведения экрана.
 

--- a/README.md
+++ b/README.md
@@ -244,8 +244,7 @@
 - [x] определить screen-level state/model для `WebView Screen`, чтобы отделить `initialURL`, loading progress, navigation title, share action availability и error state от SwiftUI `View`;
 - [x] реализовать загрузку `articleURL` в `WKWebView` с базовым loading state для первого открытия страницы;
 - [x] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;
-- [ ] добавить toolbar-кнопку закрытия экрана в левой части top bar и связать её с app-level dismiss flow обратно в `Article Screen`;
-- [ ] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;
+- [x] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;
 - [ ] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
 - [ ] добавить unit tests на app-level routing и screen-level state `WebView Screen`: открытие по `ArticleWebViewRoute`, закрытие обратно в `Article Screen`, loading/error transitions и availability `share`.
 - [ ] исследовать и определить policy для дополнительных browser actions: `open in external browser`, `reload`, page settings / reader controls / translation menu;

--- a/README.md
+++ b/README.md
@@ -247,10 +247,7 @@
 - [x] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;
 - [x] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
 - [x] добавить нижний action `open in external browser` в `bottomBar`;
-- [x] реализовать left​-edge swipe to close и зарезервировать левый edge gesture за закрытием экрана, отключив конфликтующий history navigation внутри ​WKWeb​View;
-- [x] добавить command bridge между `WebViewScreenController` и `WKWebView`, чтобы screen-level actions (`reload`, gesture refresh) не требовали хранить imperative web view state внутри SwiftUI `View`;
-- [ ] реализовать pull​-to​-refresh и определить, как он работает только в верхней точке scroll без конфликта с обычной прокруткой страницы;
-- [ ] синхронизировать `WebView Screen` с текущим page URL после navigation/redirects, чтобы `pull-to-refresh` и gesture-driven actions работали с актуальной открытой страницей, а не только с исходным `ArticleWebViewRoute.url`;
+- [x] реализовать единственный кастомный gesture `left-edge swipe to close`: edge swipe от левого края закрывает `WebView Screen` и возвращает пользователя в `Article Screen`, а встроенный history navigation внутри `WKWebView` отключён, чтобы жест не конфликтовал с поведением страницы;
 
 #### Settings Integration
 - [ ] создать `SettingsViewModel`;

--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@
 - [x] добавить нижний action `open in external browser` в `bottomBar`;
 - [x] реализовать единственный кастомный gesture `left-edge swipe to close`: edge swipe от левого края закрывает `WebView Screen` и возвращает пользователя в `Article Screen`, а встроенный history navigation внутри `WKWebView` отключён, чтобы жест не конфликтовал с поведением страницы;
 - [x] добавить нижний action `refresh` в левой части `bottomBar` и связать его с перезагрузкой текущей страницы в `WKWebView` без возврата к общему `command bridge`;
+- [x] синхронизировать `current page URL` с `WebView Screen` state, чтобы `share` и `open in external browser` использовали фактический адрес текущей открытой страницы, а не только исходный `ArticleWebViewRoute.url`;
+- [ ] привести loading presentation `WebView Screen` к тому же UI pattern, что и у `Article Screen`, чтобы первичная загрузка выглядела консистентно на уровне приложения;
+- [ ] скрывать browser actions (`share`, `refresh`, `open in external browser`) в loading/error состояниях `WebView Screen`, чтобы toolbar и `bottomBar` не предлагали действия над ещё не открытой или недоступной страницей;
+- [ ] провести `cleanup` `WebViewScreenView`: выделить секции/подвью, добавить `MARK` и упростить чтение `WKWebView` bridge-слоя без изменения поведения экрана.
 
 #### Settings Integration
 - [ ] создать `SettingsViewModel`;

--- a/README.md
+++ b/README.md
@@ -246,9 +246,9 @@
 - [x] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;
 - [x] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;
 - [x] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
-- [ ] добавить unit tests на app-level routing и screen-level state `WebView Screen`: открытие по `ArticleWebViewRoute`, закрытие обратно в `Article Screen`, loading/error transitions и availability `share`.
+- [x] добавить нижний action `open in external browser` в `bottomBar`;
 - [ ] исследовать и определить policy для дополнительных browser actions: `open in external browser`, `reload`, page settings / reader controls / translation menu;
-- [ ] добавить нижние actions `open in external browser` и `reload`, если они не конфликтуют с системным UX и компоновкой экрана;
+- [ ] добавить нижний action `reload`, если он не конфликтует с системным UX и компоновкой экрана;
 - [ ] определить, можно ли и нужно ли добавлять отдельную кнопку page settings / reader controls поверх `WKWebView`, или такие возможности должны оставаться системной ответственностью Safari / Reader mode.
 
 #### Settings Integration

--- a/README.md
+++ b/README.md
@@ -247,9 +247,10 @@
 - [x] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;
 - [x] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
 - [x] добавить нижний action `open in external browser` в `bottomBar`;
-- [ ] исследовать и определить policy для дополнительных browser actions: `open in external browser`, `reload`, page settings / reader controls / translation menu;
-- [ ] добавить нижний action `reload`, если он не конфликтует с системным UX и компоновкой экрана;
-- [ ] определить, можно ли и нужно ли добавлять отдельную кнопку page settings / reader controls поверх `WKWebView`, или такие возможности должны оставаться системной ответственностью Safari / Reader mode.
+- [x] реализовать left​-edge swipe to close и зарезервировать левый edge gesture за закрытием экрана, отключив конфликтующий history navigation внутри ​WKWeb​View;
+- [ ] добавить command bridge между `WebViewScreenController` и `WKWebView`, чтобы screen-level actions (`reload`, gesture refresh) не требовали хранить imperative web view state внутри SwiftUI `View`;
+- [ ] реализовать pull​-to​-refresh и определить, как он работает только в верхней точке scroll без конфликта с обычной прокруткой страницы;
+- [ ] синхронизировать `WebView Screen` с текущим page URL после navigation/redirects, чтобы `pull-to-refresh` и gesture-driven actions работали с актуальной открытой страницей, а не только с исходным `ArticleWebViewRoute.url`;
 
 #### Settings Integration
 - [ ] создать `SettingsViewModel`;

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@
 - [x] определить app-level navigation flow для `WebView Screen`: `RootView` должен уметь переключать detail между `Article Screen` и `WebView Screen` по `ReadingDetailRoute.webView`, а закрытие web view должно возвращать пользователя к текущей статье;
 - [x] создать отдельный `WebView Screen` на базе `WKWebView` для `articleURL`, чтобы экран получал уже подготовленный `ArticleWebViewRoute` и не знал о shell-роутинге напрямую;
 - [x] определить screen-level state/model для `WebView Screen`, чтобы отделить `initialURL`, loading progress, navigation title, share action availability и error state от SwiftUI `View`;
-- [ ] реализовать загрузку `articleURL` в `WKWebView` с базовым loading state для первого открытия страницы;
+- [x] реализовать загрузку `articleURL` в `WKWebView` с базовым loading state для первого открытия страницы;
 - [ ] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;
 - [ ] добавить toolbar-кнопку закрытия экрана в левой части top bar и связать её с app-level dismiss flow обратно в `Article Screen`;
 - [ ] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;

--- a/RSSReader/Infrastructure/AppDependencies.swift
+++ b/RSSReader/Infrastructure/AppDependencies.swift
@@ -171,7 +171,34 @@ extension AppDependencies {
 
     @MainActor
     func selectArticle(id articleID: UUID?, using appState: AppState) {
-        appState.selectedArticleID = articleID
+        guard let articleID else {
+            appState.selectedArticleID = nil
+            return
+        }
+
+        guard shouldPresentSelectedArticleInWebViewByDefault() else {
+            appState.selectedArticleID = articleID
+            return
+        }
+
+        guard let articleQueryService else {
+            logger.error("Article query service is unavailable for default reader mode policy")
+            appState.selectedArticleID = articleID
+            return
+        }
+
+        do {
+            guard let article = try articleQueryService.fetchReaderArticle(id: articleID) else {
+                logger.error("Skipped default web view presentation because article \(articleID) was not found")
+                appState.selectedArticleID = articleID
+                return
+            }
+
+            openArticleInWebView(article, using: appState)
+        } catch {
+            logger.error("Failed to apply default reader mode policy for article \(articleID): \(error)")
+            appState.selectedArticleID = articleID
+        }
     }
 
     @MainActor
@@ -293,6 +320,20 @@ extension AppDependencies {
 }
 
 private extension AppDependencies {
+    @MainActor
+    func shouldPresentSelectedArticleInWebViewByDefault() -> Bool {
+        guard let appSettingsRepository else {
+            return false
+        }
+
+        do {
+            return try appSettingsRepository.fetchOrCreate().defaultReaderMode == .browser
+        } catch {
+            logger.error("Failed to load app settings for default reader mode policy: \(error)")
+            return false
+        }
+    }
+
     static func makeFeedFetcher(
         httpClient: any HTTPClient
     ) -> any FeedFetching {

--- a/RSSReader/Views/RootView.swift
+++ b/RSSReader/Views/RootView.swift
@@ -56,6 +56,7 @@ enum ReadingShellNavigationState {
 
 struct RootView: View {
     @Environment(AppState.self) private var appState
+    @Environment(\.appDependencies) private var dependencies
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var preferredCompactColumn: NavigationSplitViewColumn = .content
 
@@ -70,7 +71,7 @@ struct RootView: View {
         )
         let articleSelection = Binding<UUID?>(
             get: { appState.selectedArticleID },
-            set: { appState.selectedArticleID = $0 }
+            set: { dependencies.selectArticle(id: $0, using: appState) }
         )
 
         NavigationSplitView(preferredCompactColumn: $preferredCompactColumn) {

--- a/RSSReader/Views/RootView.swift
+++ b/RSSReader/Views/RootView.swift
@@ -33,12 +33,37 @@ enum ArticlesScreenNavigationState {
     }
 }
 
+enum ReadingShellDetailDestination: Equatable {
+    case article(UUID?)
+    case webView(ArticleWebViewRoute)
+}
+
+enum ReadingShellNavigationState {
+    static func detailDestination(
+        route: ReadingDetailRoute,
+        selectedArticleID: UUID?
+    ) -> ReadingShellDetailDestination {
+        switch route {
+        case .none:
+            .article(selectedArticleID)
+        case .article(let articleID):
+            .article(articleID)
+        case .webView(let route):
+            .webView(route)
+        }
+    }
+}
+
 struct RootView: View {
     @Environment(AppState.self) private var appState
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var preferredCompactColumn: NavigationSplitViewColumn = .content
 
     var body: some View {
+        let detailDestination = ReadingShellNavigationState.detailDestination(
+            route: appState.selectedDetailRoute,
+            selectedArticleID: appState.selectedArticleID
+        )
         let sidebarSelection = Binding<SidebarSelection?>(
             get: { appState.selectedSidebarSelection },
             set: { appState.selectReadingSource($0) }
@@ -64,14 +89,22 @@ struct RootView: View {
                 selection: articleSelection
             )
         } detail: {
-            ReaderView(
-                articleID: appState.selectedArticleID,
-                showsBackButton: ArticleScreenNavigationState.showsBackButton(
-                    horizontalSizeClass: horizontalSizeClass,
-                    articleSelection: appState.selectedArticleID
-                ),
-                navigateBackToArticles: { appState.selectedArticleID = nil }
-            )
+            switch detailDestination {
+            case .article(let articleID):
+                ReaderView(
+                    articleID: articleID,
+                    showsBackButton: ArticleScreenNavigationState.showsBackButton(
+                        horizontalSizeClass: horizontalSizeClass,
+                        articleSelection: articleID
+                    ),
+                    navigateBackToArticles: { appState.selectedArticleID = nil }
+                )
+            case .webView(let route):
+                WebViewScreenView(
+                    route: route,
+                    closeWebView: { appState.dismissPresentedWebView() }
+                )
+            }
         }
         .onAppear(perform: syncPreferredCompactColumn)
         .onChange(of: appState.selectedSidebarSelection) { _, _ in

--- a/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
@@ -32,4 +32,8 @@ final class WebViewScreenController {
     func handleNavigationFailed(_ error: Error) {
         screenState.applyNavigationFailure(error.localizedDescription)
     }
+
+    func handleReloadRequested() {
+        screenState.requestReload()
+    }
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
@@ -32,12 +32,4 @@ final class WebViewScreenController {
     func handleNavigationFailed(_ error: Error) {
         screenState.applyNavigationFailure(error.localizedDescription)
     }
-
-    func reloadPage() {
-        screenState.enqueueReloadCommand()
-    }
-
-    func handleCommandExecution(_ command: WebViewScreenCommand) {
-        screenState.acknowledgeCommand(command)
-    }
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
@@ -6,8 +6,11 @@ import Observation
 final class WebViewScreenController {
     var screenState: WebViewScreenState
 
-    init(route: ArticleWebViewRoute) {
-        self.screenState = WebViewScreenState(route: route)
+    init(
+        route: ArticleWebViewRoute,
+        previewScreenState: WebViewScreenState? = nil
+    ) {
+        self.screenState = previewScreenState ?? WebViewScreenState(route: route)
     }
 
     func handleNavigationStarted() {

--- a/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
@@ -32,4 +32,12 @@ final class WebViewScreenController {
     func handleNavigationFailed(_ error: Error) {
         screenState.applyNavigationFailure(error.localizedDescription)
     }
+
+    func reloadPage() {
+        screenState.enqueueReloadCommand()
+    }
+
+    func handleCommandExecution(_ command: WebViewScreenCommand) {
+        screenState.acknowledgeCommand(command)
+    }
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
@@ -25,6 +25,10 @@ final class WebViewScreenController {
         screenState.applyPageTitle(title)
     }
 
+    func handleCurrentPageURLChanged(_ url: URL?) {
+        screenState.applyCurrentPageURL(url)
+    }
+
     func handleNavigationFinished() {
         screenState.applyNavigationFinished()
     }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenController.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class WebViewScreenController {
+    var screenState: WebViewScreenState
+
+    init(route: ArticleWebViewRoute) {
+        self.screenState = WebViewScreenState(route: route)
+    }
+
+    func handleNavigationStarted() {
+        screenState.applyNavigationStart()
+    }
+
+    func handleLoadingProgressChanged(_ progress: Double) {
+        screenState.applyLoadingProgress(progress)
+    }
+
+    func handlePageTitleChanged(_ title: String?) {
+        screenState.applyPageTitle(title)
+    }
+
+    func handleNavigationFinished() {
+        screenState.applyNavigationFinished()
+    }
+
+    func handleNavigationFailed(_ error: Error) {
+        screenState.applyNavigationFailure(error.localizedDescription)
+    }
+}

--- a/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
@@ -8,6 +8,20 @@ enum WebViewScreenPhase: Equatable {
 }
 
 @MainActor
+struct WebViewScreenCommand: Equatable {
+    enum Kind: Equatable {
+        case reload
+    }
+
+    let id: UUID
+    let kind: Kind
+
+    static func reload() -> WebViewScreenCommand {
+        WebViewScreenCommand(id: UUID(), kind: .reload)
+    }
+}
+
+@MainActor
 struct WebViewScreenToolbarState: Equatable {
     let shareURL: URL?
     let isShareEnabled: Bool
@@ -36,6 +50,7 @@ struct WebViewScreenDerivedViewState: Equatable {
     let phase: WebViewScreenPhase
     let loadingProgress: Double
     let showsWebViewContent: Bool
+    let pendingCommand: WebViewScreenCommand?
     let toolbar: WebViewScreenToolbarState
     let bottomActions: WebViewScreenBottomActionsState
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
@@ -8,20 +8,6 @@ enum WebViewScreenPhase: Equatable {
 }
 
 @MainActor
-struct WebViewScreenCommand: Equatable {
-    enum Kind: Equatable {
-        case reload
-    }
-
-    let id: UUID
-    let kind: Kind
-
-    static func reload() -> WebViewScreenCommand {
-        WebViewScreenCommand(id: UUID(), kind: .reload)
-    }
-}
-
-@MainActor
 struct WebViewScreenToolbarState: Equatable {
     let shareURL: URL?
     let isShareEnabled: Bool
@@ -50,7 +36,6 @@ struct WebViewScreenDerivedViewState: Equatable {
     let phase: WebViewScreenPhase
     let loadingProgress: Double
     let showsWebViewContent: Bool
-    let pendingCommand: WebViewScreenCommand?
     let toolbar: WebViewScreenToolbarState
     let bottomActions: WebViewScreenBottomActionsState
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
@@ -12,9 +12,9 @@ struct WebViewScreenToolbarState: Equatable {
     let shareURL: URL?
     let isShareEnabled: Bool
 
-    init(route: ArticleWebViewRoute, canSharePageURL: Bool) {
-        self.shareURL = canSharePageURL ? route.url : nil
-        self.isShareEnabled = canSharePageURL
+    init(pageURL: URL?) {
+        self.shareURL = pageURL
+        self.isShareEnabled = pageURL != nil
     }
 }
 
@@ -25,12 +25,12 @@ struct WebViewScreenBottomActionsState: Equatable {
     let isOpenExternalBrowserEnabled: Bool
 
     init(
-        route: ArticleWebViewRoute,
+        pageURL: URL?,
         canRefreshPage: Bool,
         canOpenExternalBrowserURL: Bool
     ) {
         self.isRefreshEnabled = canRefreshPage
-        self.openExternalBrowserURL = canOpenExternalBrowserURL ? route.url : nil
+        self.openExternalBrowserURL = canOpenExternalBrowserURL ? pageURL : nil
         self.isOpenExternalBrowserEnabled = canOpenExternalBrowserURL
     }
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@MainActor
+enum WebViewScreenPhase: Equatable {
+    case initialLoading
+    case loaded
+    case failed(String)
+}
+
+@MainActor
+struct WebViewScreenToolbarState: Equatable {
+    let shareURL: URL?
+    let isShareEnabled: Bool
+
+    init(route: ArticleWebViewRoute) {
+        self.shareURL = route.url
+        self.isShareEnabled = true
+    }
+}
+
+@MainActor
+struct WebViewScreenDerivedViewState: Equatable {
+    let initialURL: URL
+    let navigationTitle: String
+    let phase: WebViewScreenPhase
+    let loadingProgress: Double
+    let toolbar: WebViewScreenToolbarState
+}

--- a/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
@@ -12,9 +12,9 @@ struct WebViewScreenToolbarState: Equatable {
     let shareURL: URL?
     let isShareEnabled: Bool
 
-    init(route: ArticleWebViewRoute) {
-        self.shareURL = route.url
-        self.isShareEnabled = true
+    init(route: ArticleWebViewRoute, canSharePageURL: Bool) {
+        self.shareURL = canSharePageURL ? route.url : nil
+        self.isShareEnabled = canSharePageURL
     }
 }
 
@@ -24,5 +24,6 @@ struct WebViewScreenDerivedViewState: Equatable {
     let navigationTitle: String
     let phase: WebViewScreenPhase
     let loadingProgress: Double
+    let showsWebViewContent: Bool
     let toolbar: WebViewScreenToolbarState
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
@@ -19,6 +19,17 @@ struct WebViewScreenToolbarState: Equatable {
 }
 
 @MainActor
+struct WebViewScreenBottomActionsState: Equatable {
+    let openExternalBrowserURL: URL?
+    let isOpenExternalBrowserEnabled: Bool
+
+    init(route: ArticleWebViewRoute, canOpenExternalBrowserURL: Bool) {
+        self.openExternalBrowserURL = canOpenExternalBrowserURL ? route.url : nil
+        self.isOpenExternalBrowserEnabled = canOpenExternalBrowserURL
+    }
+}
+
+@MainActor
 struct WebViewScreenDerivedViewState: Equatable {
     let initialURL: URL
     let navigationTitle: String
@@ -26,4 +37,5 @@ struct WebViewScreenDerivedViewState: Equatable {
     let loadingProgress: Double
     let showsWebViewContent: Bool
     let toolbar: WebViewScreenToolbarState
+    let bottomActions: WebViewScreenBottomActionsState
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
@@ -20,10 +20,16 @@ struct WebViewScreenToolbarState: Equatable {
 
 @MainActor
 struct WebViewScreenBottomActionsState: Equatable {
+    let isRefreshEnabled: Bool
     let openExternalBrowserURL: URL?
     let isOpenExternalBrowserEnabled: Bool
 
-    init(route: ArticleWebViewRoute, canOpenExternalBrowserURL: Bool) {
+    init(
+        route: ArticleWebViewRoute,
+        canRefreshPage: Bool,
+        canOpenExternalBrowserURL: Bool
+    ) {
+        self.isRefreshEnabled = canRefreshPage
         self.openExternalBrowserURL = canOpenExternalBrowserURL ? route.url : nil
         self.isOpenExternalBrowserEnabled = canOpenExternalBrowserURL
     }
@@ -35,6 +41,7 @@ struct WebViewScreenDerivedViewState: Equatable {
     let navigationTitle: String
     let phase: WebViewScreenPhase
     let loadingProgress: Double
+    let reloadRevision: Int
     let showsWebViewContent: Bool
     let toolbar: WebViewScreenToolbarState
     let bottomActions: WebViewScreenBottomActionsState

--- a/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenPresentationModels.swift
@@ -43,6 +43,8 @@ struct WebViewScreenDerivedViewState: Equatable {
     let loadingProgress: Double
     let reloadRevision: Int
     let showsWebViewContent: Bool
+    let showsShareAction: Bool
+    let showsBottomActions: Bool
     let toolbar: WebViewScreenToolbarState
     let bottomActions: WebViewScreenBottomActionsState
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenPreviewData.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenPreviewData.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+#Preview("Loading") {
+    WebViewScreenPreviewContainer(
+        screenState: .previewLoading(
+            route: WebViewScreenPreviewData.route,
+            progress: 0.42
+        )
+    )
+}
+
+#Preview("Loaded") {
+    NavigationStack {
+        WebViewScreenView(
+            route: WebViewScreenPreviewData.route,
+            closeWebView: {}
+        )
+    }
+}
+
+#Preview("Loaded State") {
+    WebViewScreenPreviewContainer(
+        screenState: .previewLoaded(
+            route: WebViewScreenPreviewData.route,
+            title: "Example Article"
+        )
+    )
+}
+
+#Preview("Failed") {
+    WebViewScreenPreviewContainer(
+        screenState: .previewFailed(
+            route: WebViewScreenPreviewData.route,
+            message: "The page could not be loaded.",
+            title: "Example Article"
+        )
+    )
+}
+
+private struct WebViewScreenPreviewContainer: View {
+    let screenState: WebViewScreenState
+
+    var body: some View {
+        NavigationStack {
+            WebViewScreenView(
+                route: screenState.route,
+                closeWebView: {},
+                previewScreenState: screenState
+            )
+        }
+    }
+}
+
+private enum WebViewScreenPreviewData {
+    static let route = ArticleWebViewRoute(
+        articleID: UUID(),
+        url: URL(string: "https://example.com")!
+    )
+}

--- a/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
@@ -63,13 +63,17 @@ struct WebViewScreenState {
     }
 
     func derivedViewState() -> WebViewScreenDerivedViewState {
-        WebViewScreenDerivedViewState(
+        let showsBrowserActions = phase == .loaded && currentPageURL != nil
+
+        return WebViewScreenDerivedViewState(
             initialURL: route.url,
             navigationTitle: pageTitle ?? currentPageURL?.host ?? route.url.host ?? "Article",
             phase: phase,
             loadingProgress: loadingProgress,
             reloadRevision: reloadRevision,
             showsWebViewContent: route.url.isSupportedArticleWebViewURL && !phase.isFailed,
+            showsShareAction: showsBrowserActions,
+            showsBottomActions: showsBrowserActions,
             toolbar: toolbar,
             bottomActions: bottomActions
         )

--- a/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
@@ -7,6 +7,7 @@ struct WebViewScreenState {
     private(set) var pageTitle: String?
     private(set) var loadingProgress: Double = 0
     private(set) var toolbar: WebViewScreenToolbarState
+    private(set) var bottomActions: WebViewScreenBottomActionsState
 
     init(route: ArticleWebViewRoute) {
         self.route = route
@@ -14,6 +15,10 @@ struct WebViewScreenState {
         self.toolbar = WebViewScreenToolbarState(
             route: route,
             canSharePageURL: canLoadInitialURL
+        )
+        self.bottomActions = WebViewScreenBottomActionsState(
+            route: route,
+            canOpenExternalBrowserURL: canLoadInitialURL
         )
         if !canLoadInitialURL {
             self.phase = .failed("This article link can't be opened in the in-app browser.")
@@ -48,7 +53,8 @@ struct WebViewScreenState {
             phase: phase,
             loadingProgress: loadingProgress,
             showsWebViewContent: route.url.isSupportedArticleWebViewURL && !phase.isFailed,
-            toolbar: toolbar
+            toolbar: toolbar,
+            bottomActions: bottomActions
         )
     }
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
@@ -45,6 +45,39 @@ struct WebViewScreenState {
     }
 }
 
+extension WebViewScreenState {
+    static func previewLoading(
+        route: ArticleWebViewRoute,
+        progress: Double = 0.35
+    ) -> WebViewScreenState {
+        var state = WebViewScreenState(route: route)
+        state.applyNavigationStart()
+        state.applyLoadingProgress(progress)
+        return state
+    }
+
+    static func previewLoaded(
+        route: ArticleWebViewRoute,
+        title: String? = nil
+    ) -> WebViewScreenState {
+        var state = WebViewScreenState(route: route)
+        state.applyPageTitle(title)
+        state.applyNavigationFinished()
+        return state
+    }
+
+    static func previewFailed(
+        route: ArticleWebViewRoute,
+        message: String,
+        title: String? = nil
+    ) -> WebViewScreenState {
+        var state = WebViewScreenState(route: route)
+        state.applyPageTitle(title)
+        state.applyNavigationFailure(message)
+        return state
+    }
+}
+
 private extension String {
     var nilIfBlank: String? {
         let trimmedValue = trimmingCharacters(in: .whitespacesAndNewlines)

--- a/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
@@ -6,6 +6,7 @@ struct WebViewScreenState {
     private(set) var phase: WebViewScreenPhase = .initialLoading
     private(set) var pageTitle: String?
     private(set) var loadingProgress: Double = 0
+    private(set) var pendingCommand: WebViewScreenCommand?
     private(set) var toolbar: WebViewScreenToolbarState
     private(set) var bottomActions: WebViewScreenBottomActionsState
 
@@ -46,6 +47,20 @@ struct WebViewScreenState {
         phase = .failed(message)
     }
 
+    mutating func enqueueReloadCommand() {
+        guard route.url.isSupportedArticleWebViewURL else {
+            return
+        }
+        pendingCommand = .reload()
+    }
+
+    mutating func acknowledgeCommand(_ command: WebViewScreenCommand) {
+        guard pendingCommand == command else {
+            return
+        }
+        pendingCommand = nil
+    }
+
     func derivedViewState() -> WebViewScreenDerivedViewState {
         WebViewScreenDerivedViewState(
             initialURL: route.url,
@@ -53,6 +68,7 @@ struct WebViewScreenState {
             phase: phase,
             loadingProgress: loadingProgress,
             showsWebViewContent: route.url.isSupportedArticleWebViewURL && !phase.isFailed,
+            pendingCommand: pendingCommand,
             toolbar: toolbar,
             bottomActions: bottomActions
         )

--- a/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
@@ -10,7 +10,14 @@ struct WebViewScreenState {
 
     init(route: ArticleWebViewRoute) {
         self.route = route
-        self.toolbar = WebViewScreenToolbarState(route: route)
+        let canLoadInitialURL = route.url.isSupportedArticleWebViewURL
+        self.toolbar = WebViewScreenToolbarState(
+            route: route,
+            canSharePageURL: canLoadInitialURL
+        )
+        if !canLoadInitialURL {
+            self.phase = .failed("This article link can't be opened in the in-app browser.")
+        }
     }
 
     mutating func applyNavigationStart() {
@@ -40,6 +47,7 @@ struct WebViewScreenState {
             navigationTitle: pageTitle ?? route.url.host ?? "Article",
             phase: phase,
             loadingProgress: loadingProgress,
+            showsWebViewContent: route.url.isSupportedArticleWebViewURL && !phase.isFailed,
             toolbar: toolbar
         )
     }
@@ -82,5 +90,27 @@ private extension String {
     var nilIfBlank: String? {
         let trimmedValue = trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmedValue.isEmpty ? nil : trimmedValue
+    }
+}
+
+private extension URL {
+    var isSupportedArticleWebViewURL: Bool {
+        guard let scheme else {
+            return false
+        }
+        let normalizedScheme = scheme.lowercased()
+        guard normalizedScheme == "http" || normalizedScheme == "https" else {
+            return false
+        }
+        return host?.isEmpty == false
+    }
+}
+
+private extension WebViewScreenPhase {
+    var isFailed: Bool {
+        if case .failed = self {
+            return true
+        }
+        return false
     }
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+@MainActor
+struct WebViewScreenState {
+    let route: ArticleWebViewRoute
+    private(set) var phase: WebViewScreenPhase = .initialLoading
+    private(set) var pageTitle: String?
+    private(set) var loadingProgress: Double = 0
+    private(set) var toolbar: WebViewScreenToolbarState
+
+    init(route: ArticleWebViewRoute) {
+        self.route = route
+        self.toolbar = WebViewScreenToolbarState(route: route)
+    }
+
+    mutating func applyNavigationStart() {
+        phase = .initialLoading
+    }
+
+    mutating func applyLoadingProgress(_ progress: Double) {
+        loadingProgress = min(max(progress, 0), 1)
+    }
+
+    mutating func applyPageTitle(_ title: String?) {
+        pageTitle = title?.nilIfBlank
+    }
+
+    mutating func applyNavigationFinished() {
+        loadingProgress = 1
+        phase = .loaded
+    }
+
+    mutating func applyNavigationFailure(_ message: String) {
+        phase = .failed(message)
+    }
+
+    func derivedViewState() -> WebViewScreenDerivedViewState {
+        WebViewScreenDerivedViewState(
+            initialURL: route.url,
+            navigationTitle: pageTitle ?? route.url.host ?? "Article",
+            phase: phase,
+            loadingProgress: loadingProgress,
+            toolbar: toolbar
+        )
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let trimmedValue = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedValue.isEmpty ? nil : trimmedValue
+    }
+}

--- a/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
@@ -6,6 +6,7 @@ struct WebViewScreenState {
     private(set) var phase: WebViewScreenPhase = .initialLoading
     private(set) var pageTitle: String?
     private(set) var loadingProgress: Double = 0
+    private(set) var reloadRevision: Int = 0
     private(set) var toolbar: WebViewScreenToolbarState
     private(set) var bottomActions: WebViewScreenBottomActionsState
 
@@ -18,6 +19,7 @@ struct WebViewScreenState {
         )
         self.bottomActions = WebViewScreenBottomActionsState(
             route: route,
+            canRefreshPage: canLoadInitialURL,
             canOpenExternalBrowserURL: canLoadInitialURL
         )
         if !canLoadInitialURL {
@@ -46,12 +48,20 @@ struct WebViewScreenState {
         phase = .failed(message)
     }
 
+    mutating func requestReload() {
+        guard route.url.isSupportedArticleWebViewURL else {
+            return
+        }
+        reloadRevision += 1
+    }
+
     func derivedViewState() -> WebViewScreenDerivedViewState {
         WebViewScreenDerivedViewState(
             initialURL: route.url,
             navigationTitle: pageTitle ?? route.url.host ?? "Article",
             phase: phase,
             loadingProgress: loadingProgress,
+            reloadRevision: reloadRevision,
             showsWebViewContent: route.url.isSupportedArticleWebViewURL && !phase.isFailed,
             toolbar: toolbar,
             bottomActions: bottomActions

--- a/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
@@ -6,7 +6,6 @@ struct WebViewScreenState {
     private(set) var phase: WebViewScreenPhase = .initialLoading
     private(set) var pageTitle: String?
     private(set) var loadingProgress: Double = 0
-    private(set) var pendingCommand: WebViewScreenCommand?
     private(set) var toolbar: WebViewScreenToolbarState
     private(set) var bottomActions: WebViewScreenBottomActionsState
 
@@ -47,20 +46,6 @@ struct WebViewScreenState {
         phase = .failed(message)
     }
 
-    mutating func enqueueReloadCommand() {
-        guard route.url.isSupportedArticleWebViewURL else {
-            return
-        }
-        pendingCommand = .reload()
-    }
-
-    mutating func acknowledgeCommand(_ command: WebViewScreenCommand) {
-        guard pendingCommand == command else {
-            return
-        }
-        pendingCommand = nil
-    }
-
     func derivedViewState() -> WebViewScreenDerivedViewState {
         WebViewScreenDerivedViewState(
             initialURL: route.url,
@@ -68,7 +53,6 @@ struct WebViewScreenState {
             phase: phase,
             loadingProgress: loadingProgress,
             showsWebViewContent: route.url.isSupportedArticleWebViewURL && !phase.isFailed,
-            pendingCommand: pendingCommand,
             toolbar: toolbar,
             bottomActions: bottomActions
         )

--- a/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenState.swift
@@ -4,6 +4,7 @@ import Foundation
 struct WebViewScreenState {
     let route: ArticleWebViewRoute
     private(set) var phase: WebViewScreenPhase = .initialLoading
+    private(set) var currentPageURL: URL?
     private(set) var pageTitle: String?
     private(set) var loadingProgress: Double = 0
     private(set) var reloadRevision: Int = 0
@@ -13,14 +14,12 @@ struct WebViewScreenState {
     init(route: ArticleWebViewRoute) {
         self.route = route
         let canLoadInitialURL = route.url.isSupportedArticleWebViewURL
-        self.toolbar = WebViewScreenToolbarState(
-            route: route,
-            canSharePageURL: canLoadInitialURL
-        )
+        self.currentPageURL = canLoadInitialURL ? route.url : nil
+        self.toolbar = WebViewScreenToolbarState(pageURL: currentPageURL)
         self.bottomActions = WebViewScreenBottomActionsState(
-            route: route,
+            pageURL: currentPageURL,
             canRefreshPage: canLoadInitialURL,
-            canOpenExternalBrowserURL: canLoadInitialURL
+            canOpenExternalBrowserURL: currentPageURL != nil
         )
         if !canLoadInitialURL {
             self.phase = .failed("This article link can't be opened in the in-app browser.")
@@ -37,6 +36,14 @@ struct WebViewScreenState {
 
     mutating func applyPageTitle(_ title: String?) {
         pageTitle = title?.nilIfBlank
+    }
+
+    mutating func applyCurrentPageURL(_ url: URL?) {
+        guard let url else {
+            return
+        }
+        currentPageURL = url.isSupportedArticleWebViewURL ? url : nil
+        updateActionAvailability()
     }
 
     mutating func applyNavigationFinished() {
@@ -58,13 +65,24 @@ struct WebViewScreenState {
     func derivedViewState() -> WebViewScreenDerivedViewState {
         WebViewScreenDerivedViewState(
             initialURL: route.url,
-            navigationTitle: pageTitle ?? route.url.host ?? "Article",
+            navigationTitle: pageTitle ?? currentPageURL?.host ?? route.url.host ?? "Article",
             phase: phase,
             loadingProgress: loadingProgress,
             reloadRevision: reloadRevision,
             showsWebViewContent: route.url.isSupportedArticleWebViewURL && !phase.isFailed,
             toolbar: toolbar,
             bottomActions: bottomActions
+        )
+    }
+}
+
+private extension WebViewScreenState {
+    mutating func updateActionAvailability() {
+        toolbar = WebViewScreenToolbarState(pageURL: currentPageURL)
+        bottomActions = WebViewScreenBottomActionsState(
+            pageURL: currentPageURL,
+            canRefreshPage: route.url.isSupportedArticleWebViewURL,
+            canOpenExternalBrowserURL: currentPageURL != nil
         )
     }
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -1,6 +1,17 @@
 import SwiftUI
 import WebKit
 
+enum WebViewScreenNavigationState {
+    static func shouldCloseOnDrag(
+        startLocationX: CGFloat,
+        translation: CGSize
+    ) -> Bool {
+        startLocationX <= 32
+            && translation.width >= 80
+            && abs(translation.height) <= 48
+    }
+}
+
 struct WebViewScreenView: View {
     @Environment(\.openURL) private var openURL
 
@@ -74,6 +85,21 @@ struct WebViewScreenView: View {
                 )
             }
         }
+        .simultaneousGesture(closeGesture)
+    }
+
+    private var closeGesture: some Gesture {
+        DragGesture(minimumDistance: 20)
+            .onEnded { value in
+                guard WebViewScreenNavigationState.shouldCloseOnDrag(
+                    startLocationX: value.startLocation.x,
+                    translation: value.translation
+                ) else {
+                    return
+                }
+
+                closeWebView()
+            }
     }
 }
 
@@ -225,7 +251,8 @@ private struct ArticleWebView: UIViewRepresentable {
 
     func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView(frame: .zero)
-        webView.allowsBackForwardNavigationGestures = true
+        // Reserve left-edge drags for dismissing the web detail back to the article screen.
+        webView.allowsBackForwardNavigationGestures = false
         webView.navigationDelegate = context.coordinator
         context.coordinator.attachObservers(to: webView)
         webView.load(URLRequest(url: url))

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -43,11 +43,13 @@ struct WebViewScreenView: View {
             if previewScreenState == nil, viewState.showsWebViewContent {
                 ArticleWebView(
                     url: viewState.initialURL,
+                    pendingCommand: viewState.pendingCommand,
                     onNavigationStarted: controller.handleNavigationStarted,
                     onLoadingProgressChanged: controller.handleLoadingProgressChanged,
                     onPageTitleChanged: controller.handlePageTitleChanged,
                     onNavigationFinished: controller.handleNavigationFinished,
-                    onNavigationFailed: controller.handleNavigationFailed
+                    onNavigationFailed: controller.handleNavigationFailed,
+                    onCommandExecuted: controller.handleCommandExecution
                 )
             } else if previewScreenState != nil {
                 WebViewScreenPreviewSurface(url: viewState.initialURL)
@@ -233,11 +235,13 @@ private struct WebViewScreenFailureOverlay: View {
 
 private struct ArticleWebView: UIViewRepresentable {
     let url: URL
+    let pendingCommand: WebViewScreenCommand?
     let onNavigationStarted: () -> Void
     let onLoadingProgressChanged: (Double) -> Void
     let onPageTitleChanged: (String?) -> Void
     let onNavigationFinished: () -> Void
     let onNavigationFailed: (Error) -> Void
+    let onCommandExecuted: (WebViewScreenCommand) -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
@@ -245,7 +249,8 @@ private struct ArticleWebView: UIViewRepresentable {
             onLoadingProgressChanged: onLoadingProgressChanged,
             onPageTitleChanged: onPageTitleChanged,
             onNavigationFinished: onNavigationFinished,
-            onNavigationFailed: onNavigationFailed
+            onNavigationFailed: onNavigationFailed,
+            onCommandExecuted: onCommandExecuted
         )
     }
 
@@ -260,8 +265,13 @@ private struct ArticleWebView: UIViewRepresentable {
     }
 
     func updateUIView(_ webView: WKWebView, context: Context) {
-        guard webView.url != url else { return }
-        webView.load(URLRequest(url: url))
+        if webView.url != url {
+            webView.load(URLRequest(url: url))
+        }
+
+        if let pendingCommand {
+            context.coordinator.execute(command: pendingCommand, in: webView)
+        }
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
@@ -270,21 +280,39 @@ private struct ArticleWebView: UIViewRepresentable {
         private let onPageTitleChanged: (String?) -> Void
         private let onNavigationFinished: () -> Void
         private let onNavigationFailed: (Error) -> Void
+        private let onCommandExecuted: (WebViewScreenCommand) -> Void
         private var estimatedProgressObservation: NSKeyValueObservation?
         private var titleObservation: NSKeyValueObservation?
+        private var lastExecutedCommandID: UUID?
 
         init(
             onNavigationStarted: @escaping () -> Void,
             onLoadingProgressChanged: @escaping (Double) -> Void,
             onPageTitleChanged: @escaping (String?) -> Void,
             onNavigationFinished: @escaping () -> Void,
-            onNavigationFailed: @escaping (Error) -> Void
+            onNavigationFailed: @escaping (Error) -> Void,
+            onCommandExecuted: @escaping (WebViewScreenCommand) -> Void
         ) {
             self.onNavigationStarted = onNavigationStarted
             self.onLoadingProgressChanged = onLoadingProgressChanged
             self.onPageTitleChanged = onPageTitleChanged
             self.onNavigationFinished = onNavigationFinished
             self.onNavigationFailed = onNavigationFailed
+            self.onCommandExecuted = onCommandExecuted
+        }
+
+        func execute(command: WebViewScreenCommand, in webView: WKWebView) {
+            guard lastExecutedCommandID != command.id else {
+                return
+            }
+
+            switch command.kind {
+            case .reload:
+                webView.reload()
+            }
+
+            lastExecutedCommandID = command.id
+            onCommandExecuted(command)
         }
 
         func attachObservers(to webView: WKWebView) {

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -4,38 +4,151 @@ import WebKit
 struct WebViewScreenView: View {
     let route: ArticleWebViewRoute
     let closeWebView: () -> Void
+    let previewScreenState: WebViewScreenState?
     @State private var controller: WebViewScreenController
 
     init(
         route: ArticleWebViewRoute,
-        closeWebView: @escaping () -> Void
+        closeWebView: @escaping () -> Void,
+        previewScreenState: WebViewScreenState? = nil
     ) {
         self.route = route
         self.closeWebView = closeWebView
-        self._controller = State(initialValue: WebViewScreenController(route: route))
+        self.previewScreenState = previewScreenState
+        self._controller = State(
+            initialValue: WebViewScreenController(
+                route: route,
+                previewScreenState: previewScreenState
+            )
+        )
     }
 
     var body: some View {
         let viewState = controller.screenState.derivedViewState()
 
-        ArticleWebView(
-            url: viewState.initialURL,
-            onNavigationStarted: controller.handleNavigationStarted,
-            onLoadingProgressChanged: controller.handleLoadingProgressChanged,
-            onPageTitleChanged: controller.handlePageTitleChanged,
-            onNavigationFinished: controller.handleNavigationFinished,
-            onNavigationFailed: controller.handleNavigationFailed
-        )
-            .toolbarTitleDisplayMode(.inline)
-            .navigationTitle(viewState.navigationTitle)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button(action: closeWebView) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close Web View")
+        ZStack {
+            if previewScreenState == nil {
+                ArticleWebView(
+                    url: viewState.initialURL,
+                    onNavigationStarted: controller.handleNavigationStarted,
+                    onLoadingProgressChanged: controller.handleLoadingProgressChanged,
+                    onPageTitleChanged: controller.handlePageTitleChanged,
+                    onNavigationFinished: controller.handleNavigationFinished,
+                    onNavigationFailed: controller.handleNavigationFailed
+                )
+            } else {
+                WebViewScreenPreviewSurface(url: viewState.initialURL)
+            }
+
+            if viewState.phase == .initialLoading {
+                WebViewScreenLoadingOverlay(progress: viewState.loadingProgress)
+            } else if case .failed(let message) = viewState.phase {
+                WebViewScreenFailureOverlay(message: message)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+        .ignoresSafeArea(edges: [.top, .bottom])
+        .toolbarTitleDisplayMode(.inline)
+        .navigationTitle(viewState.navigationTitle)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button(action: closeWebView) {
+                    Image(systemName: "xmark")
+                }
+                .accessibilityLabel("Close Web View")
+            }
+        }
+    }
+}
+
+private struct WebViewScreenPreviewSurface: View {
+    let url: URL
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [.white, Color(.systemGray6)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 14) {
+                Text(url.absoluteString)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(.systemGray5))
+                    .frame(height: 18)
+
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(.systemGray5))
+                    .frame(height: 18)
+                    .frame(maxWidth: 240)
+
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(Color(.systemGray6))
+                    .frame(height: 220)
+
+                ForEach(0..<4, id: \.self) { index in
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(Color(.systemGray5))
+                        .frame(height: 14)
+                        .frame(maxWidth: index == 3 ? 220 : .infinity)
                 }
             }
+            .padding(20)
+        }
+    }
+}
+
+private struct WebViewScreenLoadingOverlay: View {
+    let progress: Double
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(.background.opacity(0.92))
+                .ignoresSafeArea()
+
+            VStack(spacing: 12) {
+                if progress > 0 {
+                    ProgressView(value: progress)
+                        .progressViewStyle(.linear)
+                        .frame(maxWidth: 220)
+                } else {
+                    ProgressView()
+                }
+
+                Text("Loading Page")
+                    .font(.headline)
+            }
+            .padding(24)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        }
+        .transition(.opacity)
+    }
+}
+
+private struct WebViewScreenFailureOverlay: View {
+    let message: String
+
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(.background.opacity(0.94))
+                .ignoresSafeArea()
+
+            ContentUnavailableView(
+                "Failed to Load Page",
+                systemImage: "exclamationmark.triangle",
+                description: Text(message)
+            )
+        }
+        .transition(.opacity)
     }
 }
 
@@ -132,17 +245,5 @@ private struct ArticleWebView: UIViewRepresentable {
         ) {
             onNavigationFailed(error)
         }
-    }
-}
-
-#Preview {
-    NavigationStack {
-        WebViewScreenView(
-            route: ArticleWebViewRoute(
-                articleID: UUID(),
-                url: URL(string: "https://example.com/articles/webview-preview")!
-            ),
-            closeWebView: {}
-        )
     }
 }

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct WebViewScreenView: View {
+    let route: ArticleWebViewRoute
+    let closeWebView: () -> Void
+
+    var body: some View {
+        ContentUnavailableView(
+            "Web View Screen",
+            systemImage: "globe",
+            description: Text(route.url.absoluteString)
+        )
+        .toolbarTitleDisplayMode(.inline)
+        .navigationTitle("")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button(action: closeWebView) {
+                    Image(systemName: "xmark")
+                }
+                .accessibilityLabel("Close Web View")
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        WebViewScreenView(
+            route: ArticleWebViewRoute(
+                articleID: UUID(),
+                url: URL(string: "https://example.com/articles/webview-preview")!
+            ),
+            closeWebView: {}
+        )
+    }
+}

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -1,25 +1,38 @@
 import SwiftUI
+import WebKit
 
 struct WebViewScreenView: View {
     let route: ArticleWebViewRoute
     let closeWebView: () -> Void
 
     var body: some View {
-        ContentUnavailableView(
-            "Web View Screen",
-            systemImage: "globe",
-            description: Text(route.url.absoluteString)
-        )
-        .toolbarTitleDisplayMode(.inline)
-        .navigationTitle("")
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Button(action: closeWebView) {
-                    Image(systemName: "xmark")
+        ArticleWebView(url: route.url)
+            .toolbarTitleDisplayMode(.inline)
+            .navigationTitle("")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: closeWebView) {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityLabel("Close Web View")
                 }
-                .accessibilityLabel("Close Web View")
             }
-        }
+    }
+}
+
+private struct ArticleWebView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView(frame: .zero)
+        webView.allowsBackForwardNavigationGestures = true
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        guard webView.url != url else { return }
+        webView.load(URLRequest(url: url))
     }
 }
 

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -56,7 +56,7 @@ struct WebViewScreenView: View {
             }
 
             if viewState.phase == .initialLoading {
-                WebViewScreenLoadingOverlay(progress: viewState.loadingProgress)
+                WebViewScreenPrimaryLoadingView()
             } else if case .failed(let message) = viewState.phase {
                 WebViewScreenFailureOverlay(message: message)
             }
@@ -206,31 +206,9 @@ private struct WebViewScreenPreviewSurface: View {
     }
 }
 
-private struct WebViewScreenLoadingOverlay: View {
-    let progress: Double
-
+private struct WebViewScreenPrimaryLoadingView: View {
     var body: some View {
-        ZStack {
-            Rectangle()
-                .fill(.background.opacity(0.92))
-                .ignoresSafeArea()
-
-            VStack(spacing: 12) {
-                if progress > 0 {
-                    ProgressView(value: progress)
-                        .progressViewStyle(.linear)
-                        .frame(maxWidth: 220)
-                } else {
-                    ProgressView()
-                }
-
-                Text("Loading Page")
-                    .font(.headline)
-            }
-            .padding(24)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-        }
-        .transition(.opacity)
+        ProgressView("Loading Page")
     }
 }
 

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import WebKit
 
+// MARK: - Navigation State
+
 enum WebViewScreenNavigationState {
     static func shouldCloseOnDrag(
         startLocationX: CGFloat,
@@ -11,6 +13,8 @@ enum WebViewScreenNavigationState {
             && abs(translation.height) <= 48
     }
 }
+
+// MARK: - Screen View
 
 struct WebViewScreenView: View {
     @Environment(\.openURL) private var openURL
@@ -40,26 +44,8 @@ struct WebViewScreenView: View {
         let viewState = controller.screenState.derivedViewState()
 
         ZStack {
-            if previewScreenState == nil, viewState.showsWebViewContent {
-                ArticleWebView(
-                    url: viewState.initialURL,
-                    reloadRevision: viewState.reloadRevision,
-                    onNavigationStarted: controller.handleNavigationStarted,
-                    onLoadingProgressChanged: controller.handleLoadingProgressChanged,
-                    onPageTitleChanged: controller.handlePageTitleChanged,
-                    onCurrentPageURLChanged: controller.handleCurrentPageURLChanged,
-                    onNavigationFinished: controller.handleNavigationFinished,
-                    onNavigationFailed: controller.handleNavigationFailed
-                )
-            } else if previewScreenState != nil {
-                WebViewScreenPreviewSurface(url: viewState.initialURL)
-            }
-
-            if viewState.phase == .initialLoading {
-                WebViewScreenPrimaryLoadingView()
-            } else if case .failed(let message) = viewState.phase {
-                WebViewScreenFailureOverlay(message: message)
-            }
+            contentSurface(viewState)
+            overlaySurface(viewState)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(.systemBackground))
@@ -67,39 +53,85 @@ struct WebViewScreenView: View {
         .toolbarTitleDisplayMode(.inline)
         .navigationTitle(viewState.navigationTitle)
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                Button(action: closeWebView) {
-                    Image(systemName: "xmark")
-                }
-                .accessibilityLabel("Close Web View")
-            }
-
-            if viewState.showsShareAction {
-                ToolbarItem(placement: .topBarTrailing) {
-                    WebViewScreenShareToolbarButton(toolbar: viewState.toolbar)
-                }
-            }
-
-            if viewState.showsBottomActions {
-                ToolbarItem(placement: .bottomBar) {
-                    WebViewScreenRefreshButton(
-                        bottomActions: viewState.bottomActions,
-                        refreshPage: controller.handleReloadRequested
-                    )
-                }
-
-                ToolbarSpacer(placement: .bottomBar)
-
-                ToolbarItem(placement: .bottomBar) {
-                    WebViewScreenOpenExternalBrowserButton(
-                        bottomActions: viewState.bottomActions,
-                        openURL: openURL
-                    )
-                }
-            }
+            topBarLeadingItem
+            topBarTrailingItem(viewState)
+            bottomBarItems(viewState)
         }
         .simultaneousGesture(closeGesture)
     }
+
+    // MARK: Content
+
+    @ViewBuilder
+    private func contentSurface(_ viewState: WebViewScreenDerivedViewState) -> some View {
+        if previewScreenState == nil, viewState.showsWebViewContent {
+            ArticleWebView(
+                url: viewState.initialURL,
+                reloadRevision: viewState.reloadRevision,
+                onNavigationStarted: controller.handleNavigationStarted,
+                onLoadingProgressChanged: controller.handleLoadingProgressChanged,
+                onPageTitleChanged: controller.handlePageTitleChanged,
+                onCurrentPageURLChanged: controller.handleCurrentPageURLChanged,
+                onNavigationFinished: controller.handleNavigationFinished,
+                onNavigationFailed: controller.handleNavigationFailed
+            )
+        } else if viewState.phase == .loaded {
+            WebViewScreenPreviewSurface(url: viewState.initialURL)
+        }
+    }
+
+    @ViewBuilder
+    private func overlaySurface(_ viewState: WebViewScreenDerivedViewState) -> some View {
+        if viewState.phase == .initialLoading {
+            WebViewScreenPrimaryLoadingView()
+        } else if case .failed(let message) = viewState.phase {
+            WebViewScreenFailureOverlay(message: message)
+        }
+    }
+
+    // MARK: Toolbar
+
+    @ToolbarContentBuilder
+    private var topBarLeadingItem: some ToolbarContent {
+        ToolbarItem(placement: .topBarLeading) {
+            Button(action: closeWebView) {
+                Image(systemName: "xmark")
+            }
+            .accessibilityLabel("Close Web View")
+        }
+    }
+
+    @ToolbarContentBuilder
+    private func topBarTrailingItem(_ viewState: WebViewScreenDerivedViewState) -> some ToolbarContent {
+        if viewState.showsShareAction {
+            ToolbarItem(placement: .topBarTrailing) {
+                WebViewScreenShareToolbarButton(toolbar: viewState.toolbar)
+            }
+        }
+    }
+
+    @ToolbarContentBuilder
+    private func bottomBarItems(_ viewState: WebViewScreenDerivedViewState) -> some ToolbarContent {
+        if viewState.showsBottomActions {
+            ToolbarItem(placement: .bottomBar) {
+                WebViewScreenRefreshButton(
+                    bottomActions: viewState.bottomActions,
+                    refreshPage: controller.handleReloadRequested
+                )
+            }
+
+            ToolbarSpacer(placement: .bottomBar)
+
+            ToolbarItem(placement: .bottomBar) {
+                WebViewScreenOpenExternalBrowserButton(
+                    bottomActions: viewState.bottomActions,
+                    openURL: openURL
+                )
+            }
+        }
+    }
+
+    // MARK: Gesture
 
     private var closeGesture: some Gesture {
         DragGesture(minimumDistance: 20)
@@ -115,6 +147,8 @@ struct WebViewScreenView: View {
             }
     }
 }
+
+// MARK: - Toolbar Items
 
 private struct WebViewScreenShareToolbarButton: View {
     let toolbar: WebViewScreenToolbarState
@@ -167,6 +201,8 @@ private struct WebViewScreenOpenExternalBrowserButton: View {
     }
 }
 
+// MARK: - Preview Surface
+
 private struct WebViewScreenPreviewSurface: View {
     let url: URL
 
@@ -210,9 +246,12 @@ private struct WebViewScreenPreviewSurface: View {
     }
 }
 
+// MARK: - Screen State Overlays
+
 private struct WebViewScreenPrimaryLoadingView: View {
     var body: some View {
         ProgressView("Loading Page")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 
@@ -234,6 +273,8 @@ private struct WebViewScreenFailureOverlay: View {
         .transition(.opacity)
     }
 }
+
+// MARK: - WKWebView Bridge
 
 private struct ArticleWebView: UIViewRepresentable {
     let url: URL
@@ -312,6 +353,7 @@ private struct ArticleWebView: UIViewRepresentable {
             self.onNavigationFailed = onNavigationFailed
         }
 
+        // Keep screen-level state in sync with `WKWebView` without leaking UIKit concerns into SwiftUI view code.
         func attachObservers(to webView: WKWebView) {
             estimatedProgressObservation = webView.observe(\.estimatedProgress, options: [.initial, .new]) { [weak self] webView, _ in
                 self?.onLoadingProgressChanged(webView.estimatedProgress)

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -43,13 +43,11 @@ struct WebViewScreenView: View {
             if previewScreenState == nil, viewState.showsWebViewContent {
                 ArticleWebView(
                     url: viewState.initialURL,
-                    pendingCommand: viewState.pendingCommand,
                     onNavigationStarted: controller.handleNavigationStarted,
                     onLoadingProgressChanged: controller.handleLoadingProgressChanged,
                     onPageTitleChanged: controller.handlePageTitleChanged,
                     onNavigationFinished: controller.handleNavigationFinished,
-                    onNavigationFailed: controller.handleNavigationFailed,
-                    onCommandExecuted: controller.handleCommandExecution
+                    onNavigationFailed: controller.handleNavigationFailed
                 )
             } else if previewScreenState != nil {
                 WebViewScreenPreviewSurface(url: viewState.initialURL)
@@ -235,13 +233,11 @@ private struct WebViewScreenFailureOverlay: View {
 
 private struct ArticleWebView: UIViewRepresentable {
     let url: URL
-    let pendingCommand: WebViewScreenCommand?
     let onNavigationStarted: () -> Void
     let onLoadingProgressChanged: (Double) -> Void
     let onPageTitleChanged: (String?) -> Void
     let onNavigationFinished: () -> Void
     let onNavigationFailed: (Error) -> Void
-    let onCommandExecuted: (WebViewScreenCommand) -> Void
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
@@ -249,8 +245,7 @@ private struct ArticleWebView: UIViewRepresentable {
             onLoadingProgressChanged: onLoadingProgressChanged,
             onPageTitleChanged: onPageTitleChanged,
             onNavigationFinished: onNavigationFinished,
-            onNavigationFailed: onNavigationFailed,
-            onCommandExecuted: onCommandExecuted
+            onNavigationFailed: onNavigationFailed
         )
     }
 
@@ -268,10 +263,6 @@ private struct ArticleWebView: UIViewRepresentable {
         if webView.url != url {
             webView.load(URLRequest(url: url))
         }
-
-        if let pendingCommand {
-            context.coordinator.execute(command: pendingCommand, in: webView)
-        }
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
@@ -280,39 +271,21 @@ private struct ArticleWebView: UIViewRepresentable {
         private let onPageTitleChanged: (String?) -> Void
         private let onNavigationFinished: () -> Void
         private let onNavigationFailed: (Error) -> Void
-        private let onCommandExecuted: (WebViewScreenCommand) -> Void
         private var estimatedProgressObservation: NSKeyValueObservation?
         private var titleObservation: NSKeyValueObservation?
-        private var lastExecutedCommandID: UUID?
 
         init(
             onNavigationStarted: @escaping () -> Void,
             onLoadingProgressChanged: @escaping (Double) -> Void,
             onPageTitleChanged: @escaping (String?) -> Void,
             onNavigationFinished: @escaping () -> Void,
-            onNavigationFailed: @escaping (Error) -> Void,
-            onCommandExecuted: @escaping (WebViewScreenCommand) -> Void
+            onNavigationFailed: @escaping (Error) -> Void
         ) {
             self.onNavigationStarted = onNavigationStarted
             self.onLoadingProgressChanged = onLoadingProgressChanged
             self.onPageTitleChanged = onPageTitleChanged
             self.onNavigationFinished = onNavigationFinished
             self.onNavigationFailed = onNavigationFailed
-            self.onCommandExecuted = onCommandExecuted
-        }
-
-        func execute(command: WebViewScreenCommand, in webView: WKWebView) {
-            guard lastExecutedCommandID != command.id else {
-                return
-            }
-
-            switch command.kind {
-            case .reload:
-                webView.reload()
-            }
-
-            lastExecutedCommandID = command.id
-            onCommandExecuted(command)
         }
 
         func attachObservers(to webView: WKWebView) {

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -58,7 +58,29 @@ struct WebViewScreenView: View {
                 }
                 .accessibilityLabel("Close Web View")
             }
+
+            ToolbarItem(placement: .topBarTrailing) {
+                WebViewScreenShareToolbarButton(toolbar: viewState.toolbar)
+            }
         }
+    }
+}
+
+private struct WebViewScreenShareToolbarButton: View {
+    let toolbar: WebViewScreenToolbarState
+
+    var body: some View {
+        Group {
+            if let shareURL = toolbar.shareURL {
+                ShareLink(item: shareURL) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+            } else {
+                Image(systemName: "square.and.arrow.up")
+            }
+        }
+        .accessibilityLabel("Share Page")
+        .disabled(toolbar.isShareEnabled == false)
     }
 }
 

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -4,11 +4,30 @@ import WebKit
 struct WebViewScreenView: View {
     let route: ArticleWebViewRoute
     let closeWebView: () -> Void
+    @State private var controller: WebViewScreenController
+
+    init(
+        route: ArticleWebViewRoute,
+        closeWebView: @escaping () -> Void
+    ) {
+        self.route = route
+        self.closeWebView = closeWebView
+        self._controller = State(initialValue: WebViewScreenController(route: route))
+    }
 
     var body: some View {
-        ArticleWebView(url: route.url)
+        let viewState = controller.screenState.derivedViewState()
+
+        ArticleWebView(
+            url: viewState.initialURL,
+            onNavigationStarted: controller.handleNavigationStarted,
+            onLoadingProgressChanged: controller.handleLoadingProgressChanged,
+            onPageTitleChanged: controller.handlePageTitleChanged,
+            onNavigationFinished: controller.handleNavigationFinished,
+            onNavigationFailed: controller.handleNavigationFailed
+        )
             .toolbarTitleDisplayMode(.inline)
-            .navigationTitle("")
+            .navigationTitle(viewState.navigationTitle)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(action: closeWebView) {
@@ -22,10 +41,27 @@ struct WebViewScreenView: View {
 
 private struct ArticleWebView: UIViewRepresentable {
     let url: URL
+    let onNavigationStarted: () -> Void
+    let onLoadingProgressChanged: (Double) -> Void
+    let onPageTitleChanged: (String?) -> Void
+    let onNavigationFinished: () -> Void
+    let onNavigationFailed: (Error) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            onNavigationStarted: onNavigationStarted,
+            onLoadingProgressChanged: onLoadingProgressChanged,
+            onPageTitleChanged: onPageTitleChanged,
+            onNavigationFinished: onNavigationFinished,
+            onNavigationFailed: onNavigationFailed
+        )
+    }
 
     func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView(frame: .zero)
         webView.allowsBackForwardNavigationGestures = true
+        webView.navigationDelegate = context.coordinator
+        context.coordinator.attachObservers(to: webView)
         webView.load(URLRequest(url: url))
         return webView
     }
@@ -33,6 +69,69 @@ private struct ArticleWebView: UIViewRepresentable {
     func updateUIView(_ webView: WKWebView, context: Context) {
         guard webView.url != url else { return }
         webView.load(URLRequest(url: url))
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        private let onNavigationStarted: () -> Void
+        private let onLoadingProgressChanged: (Double) -> Void
+        private let onPageTitleChanged: (String?) -> Void
+        private let onNavigationFinished: () -> Void
+        private let onNavigationFailed: (Error) -> Void
+        private var estimatedProgressObservation: NSKeyValueObservation?
+        private var titleObservation: NSKeyValueObservation?
+
+        init(
+            onNavigationStarted: @escaping () -> Void,
+            onLoadingProgressChanged: @escaping (Double) -> Void,
+            onPageTitleChanged: @escaping (String?) -> Void,
+            onNavigationFinished: @escaping () -> Void,
+            onNavigationFailed: @escaping (Error) -> Void
+        ) {
+            self.onNavigationStarted = onNavigationStarted
+            self.onLoadingProgressChanged = onLoadingProgressChanged
+            self.onPageTitleChanged = onPageTitleChanged
+            self.onNavigationFinished = onNavigationFinished
+            self.onNavigationFailed = onNavigationFailed
+        }
+
+        func attachObservers(to webView: WKWebView) {
+            estimatedProgressObservation = webView.observe(\.estimatedProgress, options: [.initial, .new]) { [weak self] webView, _ in
+                self?.onLoadingProgressChanged(webView.estimatedProgress)
+            }
+            titleObservation = webView.observe(\.title, options: [.initial, .new]) { [weak self] webView, _ in
+                self?.onPageTitleChanged(webView.title)
+            }
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didStartProvisionalNavigation navigation: WKNavigation!
+        ) {
+            onNavigationStarted()
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFinish navigation: WKNavigation!
+        ) {
+            onNavigationFinished()
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFail navigation: WKNavigation!,
+            withError error: Error
+        ) {
+            onNavigationFailed(error)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didFailProvisionalNavigation navigation: WKNavigation!,
+            withError error: Error
+        ) {
+            onNavigationFailed(error)
+        }
     }
 }
 

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -43,6 +43,7 @@ struct WebViewScreenView: View {
             if previewScreenState == nil, viewState.showsWebViewContent {
                 ArticleWebView(
                     url: viewState.initialURL,
+                    reloadRevision: viewState.reloadRevision,
                     onNavigationStarted: controller.handleNavigationStarted,
                     onLoadingProgressChanged: controller.handleLoadingProgressChanged,
                     onPageTitleChanged: controller.handlePageTitleChanged,
@@ -74,6 +75,13 @@ struct WebViewScreenView: View {
 
             ToolbarItem(placement: .topBarTrailing) {
                 WebViewScreenShareToolbarButton(toolbar: viewState.toolbar)
+            }
+
+            ToolbarItem(placement: .bottomBar) {
+                WebViewScreenRefreshButton(
+                    bottomActions: viewState.bottomActions,
+                    refreshPage: controller.handleReloadRequested
+                )
             }
 
             ToolbarSpacer(placement: .bottomBar)
@@ -118,6 +126,19 @@ private struct WebViewScreenShareToolbarButton: View {
         }
         .accessibilityLabel("Share Page")
         .disabled(toolbar.isShareEnabled == false)
+    }
+}
+
+private struct WebViewScreenRefreshButton: View {
+    let bottomActions: WebViewScreenBottomActionsState
+    let refreshPage: () -> Void
+
+    var body: some View {
+        Button(action: refreshPage) {
+            Image(systemName: "arrow.clockwise")
+        }
+        .disabled(bottomActions.isRefreshEnabled == false)
+        .accessibilityLabel("Reload Page")
     }
 }
 
@@ -233,6 +254,7 @@ private struct WebViewScreenFailureOverlay: View {
 
 private struct ArticleWebView: UIViewRepresentable {
     let url: URL
+    let reloadRevision: Int
     let onNavigationStarted: () -> Void
     let onLoadingProgressChanged: (Double) -> Void
     let onPageTitleChanged: (String?) -> Void
@@ -255,6 +277,7 @@ private struct ArticleWebView: UIViewRepresentable {
         webView.allowsBackForwardNavigationGestures = false
         webView.navigationDelegate = context.coordinator
         context.coordinator.attachObservers(to: webView)
+        context.coordinator.lastReloadRevision = reloadRevision
         webView.load(URLRequest(url: url))
         return webView
     }
@@ -262,6 +285,17 @@ private struct ArticleWebView: UIViewRepresentable {
     func updateUIView(_ webView: WKWebView, context: Context) {
         if webView.url != url {
             webView.load(URLRequest(url: url))
+            context.coordinator.lastReloadRevision = reloadRevision
+            return
+        }
+
+        if context.coordinator.lastReloadRevision != reloadRevision {
+            context.coordinator.lastReloadRevision = reloadRevision
+            if webView.url == nil {
+                webView.load(URLRequest(url: url))
+            } else {
+                webView.reload()
+            }
         }
     }
 
@@ -273,6 +307,7 @@ private struct ArticleWebView: UIViewRepresentable {
         private let onNavigationFailed: (Error) -> Void
         private var estimatedProgressObservation: NSKeyValueObservation?
         private var titleObservation: NSKeyValueObservation?
+        var lastReloadRevision: Int = 0
 
         init(
             onNavigationStarted: @escaping () -> Void,

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import WebKit
 
 struct WebViewScreenView: View {
+    @Environment(\.openURL) private var openURL
+
     let route: ArticleWebViewRoute
     let closeWebView: () -> Void
     let previewScreenState: WebViewScreenState?
@@ -62,6 +64,15 @@ struct WebViewScreenView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 WebViewScreenShareToolbarButton(toolbar: viewState.toolbar)
             }
+
+            ToolbarSpacer(placement: .bottomBar)
+
+            ToolbarItem(placement: .bottomBar) {
+                WebViewScreenOpenExternalBrowserButton(
+                    bottomActions: viewState.bottomActions,
+                    openURL: openURL
+                )
+            }
         }
     }
 }
@@ -81,6 +92,26 @@ private struct WebViewScreenShareToolbarButton: View {
         }
         .accessibilityLabel("Share Page")
         .disabled(toolbar.isShareEnabled == false)
+    }
+}
+
+private struct WebViewScreenOpenExternalBrowserButton: View {
+    let bottomActions: WebViewScreenBottomActionsState
+    let openURL: OpenURLAction
+
+    var body: some View {
+        Button(action: openExternalBrowser) {
+            Image(systemName: "safari")
+        }
+        .disabled(bottomActions.isOpenExternalBrowserEnabled == false)
+        .accessibilityLabel("Open in External Browser")
+    }
+
+    private func openExternalBrowser() {
+        guard let url = bottomActions.openExternalBrowserURL else {
+            return
+        }
+        openURL(url)
     }
 }
 

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -47,6 +47,7 @@ struct WebViewScreenView: View {
                     onNavigationStarted: controller.handleNavigationStarted,
                     onLoadingProgressChanged: controller.handleLoadingProgressChanged,
                     onPageTitleChanged: controller.handlePageTitleChanged,
+                    onCurrentPageURLChanged: controller.handleCurrentPageURLChanged,
                     onNavigationFinished: controller.handleNavigationFinished,
                     onNavigationFailed: controller.handleNavigationFailed
                 )
@@ -258,6 +259,7 @@ private struct ArticleWebView: UIViewRepresentable {
     let onNavigationStarted: () -> Void
     let onLoadingProgressChanged: (Double) -> Void
     let onPageTitleChanged: (String?) -> Void
+    let onCurrentPageURLChanged: (URL?) -> Void
     let onNavigationFinished: () -> Void
     let onNavigationFailed: (Error) -> Void
 
@@ -266,6 +268,7 @@ private struct ArticleWebView: UIViewRepresentable {
             onNavigationStarted: onNavigationStarted,
             onLoadingProgressChanged: onLoadingProgressChanged,
             onPageTitleChanged: onPageTitleChanged,
+            onCurrentPageURLChanged: onCurrentPageURLChanged,
             onNavigationFinished: onNavigationFinished,
             onNavigationFailed: onNavigationFailed
         )
@@ -303,22 +306,26 @@ private struct ArticleWebView: UIViewRepresentable {
         private let onNavigationStarted: () -> Void
         private let onLoadingProgressChanged: (Double) -> Void
         private let onPageTitleChanged: (String?) -> Void
+        private let onCurrentPageURLChanged: (URL?) -> Void
         private let onNavigationFinished: () -> Void
         private let onNavigationFailed: (Error) -> Void
         private var estimatedProgressObservation: NSKeyValueObservation?
         private var titleObservation: NSKeyValueObservation?
+        private var urlObservation: NSKeyValueObservation?
         var lastReloadRevision: Int = 0
 
         init(
             onNavigationStarted: @escaping () -> Void,
             onLoadingProgressChanged: @escaping (Double) -> Void,
             onPageTitleChanged: @escaping (String?) -> Void,
+            onCurrentPageURLChanged: @escaping (URL?) -> Void,
             onNavigationFinished: @escaping () -> Void,
             onNavigationFailed: @escaping (Error) -> Void
         ) {
             self.onNavigationStarted = onNavigationStarted
             self.onLoadingProgressChanged = onLoadingProgressChanged
             self.onPageTitleChanged = onPageTitleChanged
+            self.onCurrentPageURLChanged = onCurrentPageURLChanged
             self.onNavigationFinished = onNavigationFinished
             self.onNavigationFailed = onNavigationFailed
         }
@@ -329,6 +336,9 @@ private struct ArticleWebView: UIViewRepresentable {
             }
             titleObservation = webView.observe(\.title, options: [.initial, .new]) { [weak self] webView, _ in
                 self?.onPageTitleChanged(webView.title)
+            }
+            urlObservation = webView.observe(\.url, options: [.new]) { [weak self] webView, _ in
+                self?.onCurrentPageURLChanged(webView.url)
             }
         }
 

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -74,24 +74,28 @@ struct WebViewScreenView: View {
                 .accessibilityLabel("Close Web View")
             }
 
-            ToolbarItem(placement: .topBarTrailing) {
-                WebViewScreenShareToolbarButton(toolbar: viewState.toolbar)
+            if viewState.showsShareAction {
+                ToolbarItem(placement: .topBarTrailing) {
+                    WebViewScreenShareToolbarButton(toolbar: viewState.toolbar)
+                }
             }
 
-            ToolbarItem(placement: .bottomBar) {
-                WebViewScreenRefreshButton(
-                    bottomActions: viewState.bottomActions,
-                    refreshPage: controller.handleReloadRequested
-                )
-            }
+            if viewState.showsBottomActions {
+                ToolbarItem(placement: .bottomBar) {
+                    WebViewScreenRefreshButton(
+                        bottomActions: viewState.bottomActions,
+                        refreshPage: controller.handleReloadRequested
+                    )
+                }
 
-            ToolbarSpacer(placement: .bottomBar)
+                ToolbarSpacer(placement: .bottomBar)
 
-            ToolbarItem(placement: .bottomBar) {
-                WebViewScreenOpenExternalBrowserButton(
-                    bottomActions: viewState.bottomActions,
-                    openURL: openURL
-                )
+                ToolbarItem(placement: .bottomBar) {
+                    WebViewScreenOpenExternalBrowserButton(
+                        bottomActions: viewState.bottomActions,
+                        openURL: openURL
+                    )
+                }
             }
         }
         .simultaneousGesture(closeGesture)

--- a/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
+++ b/RSSReader/Views/WebViewScreen/WebViewScreenView.swift
@@ -27,7 +27,7 @@ struct WebViewScreenView: View {
         let viewState = controller.screenState.derivedViewState()
 
         ZStack {
-            if previewScreenState == nil {
+            if previewScreenState == nil, viewState.showsWebViewContent {
                 ArticleWebView(
                     url: viewState.initialURL,
                     onNavigationStarted: controller.handleNavigationStarted,
@@ -36,7 +36,7 @@ struct WebViewScreenView: View {
                     onNavigationFinished: controller.handleNavigationFinished,
                     onNavigationFailed: controller.handleNavigationFailed
                 )
-            } else {
+            } else if previewScreenState != nil {
                 WebViewScreenPreviewSurface(url: viewState.initialURL)
             }
 
@@ -142,11 +142,11 @@ private struct WebViewScreenFailureOverlay: View {
                 .fill(.background.opacity(0.94))
                 .ignoresSafeArea()
 
-            ContentUnavailableView(
-                "Failed to Load Page",
-                systemImage: "exclamationmark.triangle",
-                description: Text(message)
-            )
+            ContentUnavailableView {
+                Label("Failed to Load Page", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(message)
+            }
         }
         .transition(.opacity)
     }

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1538,23 +1538,6 @@ struct RSSReaderTests {
     }
 
     @Test
-    func webViewScreenStateEnqueuesAndAcknowledgesReloadCommand() {
-        let route = ArticleWebViewRoute(
-            articleID: UUID(),
-            url: URL(string: "https://example.com/articles/webview-state-reload")!
-        )
-        var state = WebViewScreenState(route: route)
-
-        state.enqueueReloadCommand()
-        let pendingCommand = try! #require(state.derivedViewState().pendingCommand)
-        #expect(pendingCommand.kind == .reload)
-
-        state.acknowledgeCommand(pendingCommand)
-
-        #expect(state.derivedViewState().pendingCommand == nil)
-    }
-
-    @Test
     func webViewScreenStateStartsInFailurePhaseForUnsupportedInitialURL() {
         let route = ArticleWebViewRoute(
             articleID: UUID(),
@@ -1572,24 +1555,6 @@ struct RSSReaderTests {
         #expect(viewState.toolbar.isShareEnabled == false)
         #expect(viewState.bottomActions.openExternalBrowserURL == nil)
         #expect(viewState.bottomActions.isOpenExternalBrowserEnabled == false)
-        #expect(viewState.pendingCommand == nil)
-    }
-
-    @Test
-    func webViewScreenControllerBridgesReloadCommandWithoutKeepingItInViewStateForever() {
-        let route = ArticleWebViewRoute(
-            articleID: UUID(),
-            url: URL(string: "https://example.com/articles/webview-controller-reload")!
-        )
-        let controller = WebViewScreenController(route: route)
-
-        controller.reloadPage()
-        let pendingCommand = try! #require(controller.screenState.derivedViewState().pendingCommand)
-        #expect(pendingCommand.kind == .reload)
-
-        controller.handleCommandExecution(pendingCommand)
-
-        #expect(controller.screenState.derivedViewState().pendingCommand == nil)
     }
 
     @Test

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1475,6 +1475,8 @@ struct RSSReaderTests {
         #expect(viewState.showsWebViewContent)
         #expect(viewState.toolbar.shareURL == route.url)
         #expect(viewState.toolbar.isShareEnabled)
+        #expect(viewState.bottomActions.openExternalBrowserURL == route.url)
+        #expect(viewState.bottomActions.isOpenExternalBrowserEnabled)
     }
 
     @Test
@@ -1521,6 +1523,8 @@ struct RSSReaderTests {
         #expect(viewState.showsWebViewContent == false)
         #expect(viewState.toolbar.shareURL == nil)
         #expect(viewState.toolbar.isShareEnabled == false)
+        #expect(viewState.bottomActions.openExternalBrowserURL == nil)
+        #expect(viewState.bottomActions.isOpenExternalBrowserEnabled == false)
     }
 
     @Test

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1502,9 +1502,11 @@ struct RSSReaderTests {
         #expect(viewState.navigationTitle == "example.com")
         #expect(viewState.phase == .initialLoading)
         #expect(viewState.loadingProgress == 0)
+        #expect(viewState.reloadRevision == 0)
         #expect(viewState.showsWebViewContent)
         #expect(viewState.toolbar.shareURL == route.url)
         #expect(viewState.toolbar.isShareEnabled)
+        #expect(viewState.bottomActions.isRefreshEnabled)
         #expect(viewState.bottomActions.openExternalBrowserURL == route.url)
         #expect(viewState.bottomActions.isOpenExternalBrowserEnabled)
     }
@@ -1538,6 +1540,29 @@ struct RSSReaderTests {
     }
 
     @Test
+    func webViewScreenStateIncrementsReloadRevisionOnlyForSupportedURLs() {
+        let supportedRoute = ArticleWebViewRoute(
+            articleID: UUID(),
+            url: URL(string: "https://example.com/articles/webview-reload")!
+        )
+        var supportedState = WebViewScreenState(route: supportedRoute)
+
+        supportedState.requestReload()
+
+        #expect(supportedState.derivedViewState().reloadRevision == 1)
+
+        let unsupportedRoute = ArticleWebViewRoute(
+            articleID: UUID(),
+            url: URL(string: "mailto:hello@example.com")!
+        )
+        var unsupportedState = WebViewScreenState(route: unsupportedRoute)
+
+        unsupportedState.requestReload()
+
+        #expect(unsupportedState.derivedViewState().reloadRevision == 0)
+    }
+
+    @Test
     func webViewScreenStateStartsInFailurePhaseForUnsupportedInitialURL() {
         let route = ArticleWebViewRoute(
             articleID: UUID(),
@@ -1553,6 +1578,7 @@ struct RSSReaderTests {
         #expect(viewState.showsWebViewContent == false)
         #expect(viewState.toolbar.shareURL == nil)
         #expect(viewState.toolbar.isShareEnabled == false)
+        #expect(viewState.bottomActions.isRefreshEnabled == false)
         #expect(viewState.bottomActions.openExternalBrowserURL == nil)
         #expect(viewState.bottomActions.isOpenExternalBrowserEnabled == false)
     }

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1504,6 +1504,8 @@ struct RSSReaderTests {
         #expect(viewState.loadingProgress == 0)
         #expect(viewState.reloadRevision == 0)
         #expect(viewState.showsWebViewContent)
+        #expect(viewState.showsShareAction == false)
+        #expect(viewState.showsBottomActions == false)
         #expect(viewState.toolbar.shareURL == route.url)
         #expect(viewState.toolbar.isShareEnabled)
         #expect(viewState.bottomActions.isRefreshEnabled)
@@ -1527,16 +1529,22 @@ struct RSSReaderTests {
         #expect(viewState.phase == .initialLoading)
         #expect(viewState.loadingProgress == 0.42)
         #expect(viewState.navigationTitle == "Loaded Article")
+        #expect(viewState.showsShareAction == false)
+        #expect(viewState.showsBottomActions == false)
 
         state.applyNavigationFinished()
         viewState = state.derivedViewState()
         #expect(viewState.phase == .loaded)
         #expect(viewState.loadingProgress == 1)
+        #expect(viewState.showsShareAction)
+        #expect(viewState.showsBottomActions)
 
         state.applyNavigationFailure("The page could not be loaded.")
         viewState = state.derivedViewState()
         #expect(viewState.phase == .failed("The page could not be loaded."))
         #expect(viewState.showsWebViewContent == false)
+        #expect(viewState.showsShareAction == false)
+        #expect(viewState.showsBottomActions == false)
     }
 
     @Test
@@ -1602,6 +1610,8 @@ struct RSSReaderTests {
         )
         #expect(viewState.navigationTitle == "Article")
         #expect(viewState.showsWebViewContent == false)
+        #expect(viewState.showsShareAction == false)
+        #expect(viewState.showsBottomActions == false)
         #expect(viewState.toolbar.shareURL == nil)
         #expect(viewState.toolbar.isShareEnabled == false)
         #expect(viewState.bottomActions.isRefreshEnabled == false)

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1421,6 +1421,45 @@ struct RSSReaderTests {
     }
 
     @Test
+    func readingShellNavigationStateBuildsArticleDestinationForNoneAndArticleRoutes() {
+        let articleID = UUID()
+
+        #expect(
+            ReadingShellNavigationState.detailDestination(
+                route: .none,
+                selectedArticleID: nil
+            ) == .article(nil)
+        )
+        #expect(
+            ReadingShellNavigationState.detailDestination(
+                route: .none,
+                selectedArticleID: articleID
+            ) == .article(articleID)
+        )
+        #expect(
+            ReadingShellNavigationState.detailDestination(
+                route: .article(articleID),
+                selectedArticleID: nil
+            ) == .article(articleID)
+        )
+    }
+
+    @Test
+    func readingShellNavigationStateBuildsWebViewDestinationForWebViewRoute() {
+        let route = ArticleWebViewRoute(
+            articleID: UUID(),
+            url: URL(string: "https://example.com/web-shell-destination")!
+        )
+
+        #expect(
+            ReadingShellNavigationState.detailDestination(
+                route: .webView(route),
+                selectedArticleID: route.articleID
+            ) == .webView(route)
+        )
+    }
+
+    @Test
     func articlesScreenStateStartsWithoutSelectionPlaceholder() {
         let state = ArticlesScreenState()
 

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -2840,6 +2840,43 @@ struct RSSReaderTests {
     }
 
     @Test
+    func shellActionEntryPointsSelectArticleOpensWebViewWhenDefaultReaderModeIsBrowser() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appState = AppState()
+        let feeds = try harness.insertFeeds(urls: ["https://example.com/default-reader-mode.xml"])
+        let feed = try #require(feeds.first)
+        let articleModel = try harness.insertArticle(
+            feed: feed,
+            externalID: "default-browser-article",
+            url: "https://example.com/articles/browser-mode",
+            title: "Default Browser Mode Article"
+        )
+        articleModel.canonicalURL = "https://example.com/articles/browser-mode/canonical"
+        try harness.dependencies.appSettingsRepository?.update(
+            AppSettingsUpdate(defaultReaderMode: .browser)
+        )
+        try harness.saveModelContext()
+
+        harness.dependencies.selectArticle(id: articleModel.id, using: appState)
+
+        #expect(appState.selectedArticleID == articleModel.id)
+        #expect(
+            appState.selectedDetailRoute == .webView(
+                ArticleWebViewRoute(
+                    articleID: articleModel.id,
+                    url: URL(string: "https://example.com/articles/browser-mode/canonical")!
+                )
+            )
+        )
+        #expect(
+            appState.presentedWebViewRoute == ArticleWebViewRoute(
+                articleID: articleModel.id,
+                url: URL(string: "https://example.com/articles/browser-mode/canonical")!
+            )
+        )
+    }
+
+    @Test
     func shellActionEntryPointsRefreshCurrentSourceTriggersReloadAfterFeedRefresh() async throws {
         let client = ScriptedHTTPClient(
             responsesByURL: [

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1472,6 +1472,7 @@ struct RSSReaderTests {
         #expect(viewState.navigationTitle == "example.com")
         #expect(viewState.phase == .initialLoading)
         #expect(viewState.loadingProgress == 0)
+        #expect(viewState.showsWebViewContent)
         #expect(viewState.toolbar.shareURL == route.url)
         #expect(viewState.toolbar.isShareEnabled)
     }
@@ -1501,6 +1502,25 @@ struct RSSReaderTests {
         state.applyNavigationFailure("The page could not be loaded.")
         viewState = state.derivedViewState()
         #expect(viewState.phase == .failed("The page could not be loaded."))
+        #expect(viewState.showsWebViewContent == false)
+    }
+
+    @Test
+    func webViewScreenStateStartsInFailurePhaseForUnsupportedInitialURL() {
+        let route = ArticleWebViewRoute(
+            articleID: UUID(),
+            url: URL(string: "mailto:hello@example.com")!
+        )
+        let state = WebViewScreenState(route: route)
+        let viewState = state.derivedViewState()
+
+        #expect(
+            viewState.phase == .failed("This article link can't be opened in the in-app browser.")
+        )
+        #expect(viewState.navigationTitle == "Article")
+        #expect(viewState.showsWebViewContent == false)
+        #expect(viewState.toolbar.shareURL == nil)
+        #expect(viewState.toolbar.isShareEnabled == false)
     }
 
     @Test

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1460,6 +1460,36 @@ struct RSSReaderTests {
     }
 
     @Test
+    func webViewScreenNavigationStateClosesOnLeftEdgeHorizontalDrag() {
+        #expect(
+            WebViewScreenNavigationState.shouldCloseOnDrag(
+                startLocationX: 12,
+                translation: CGSize(width: 96, height: 10)
+            )
+        )
+    }
+
+    @Test
+    func webViewScreenNavigationStateIgnoresDragsAwayFromLeftEdge() {
+        #expect(
+            WebViewScreenNavigationState.shouldCloseOnDrag(
+                startLocationX: 48,
+                translation: CGSize(width: 96, height: 8)
+            ) == false
+        )
+    }
+
+    @Test
+    func webViewScreenNavigationStateIgnoresMostlyVerticalDrags() {
+        #expect(
+            WebViewScreenNavigationState.shouldCloseOnDrag(
+                startLocationX: 10,
+                translation: CGSize(width: 96, height: 64)
+            ) == false
+        )
+    }
+
+    @Test
     func webViewScreenStateBuildsInitialDerivedStateFromRoute() {
         let route = ArticleWebViewRoute(
             articleID: UUID(),

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1460,6 +1460,50 @@ struct RSSReaderTests {
     }
 
     @Test
+    func webViewScreenStateBuildsInitialDerivedStateFromRoute() {
+        let route = ArticleWebViewRoute(
+            articleID: UUID(),
+            url: URL(string: "https://example.com/articles/webview-state")!
+        )
+        let state = WebViewScreenState(route: route)
+        let viewState = state.derivedViewState()
+
+        #expect(viewState.initialURL == route.url)
+        #expect(viewState.navigationTitle == "example.com")
+        #expect(viewState.phase == .initialLoading)
+        #expect(viewState.loadingProgress == 0)
+        #expect(viewState.toolbar.shareURL == route.url)
+        #expect(viewState.toolbar.isShareEnabled)
+    }
+
+    @Test
+    func webViewScreenStateTracksTitleLoadingProgressAndFailureIndependentlyFromView() {
+        let route = ArticleWebViewRoute(
+            articleID: UUID(),
+            url: URL(string: "https://example.com/articles/webview-state-progress")!
+        )
+        var state = WebViewScreenState(route: route)
+
+        state.applyNavigationStart()
+        state.applyLoadingProgress(0.42)
+        state.applyPageTitle("Loaded Article")
+
+        var viewState = state.derivedViewState()
+        #expect(viewState.phase == .initialLoading)
+        #expect(viewState.loadingProgress == 0.42)
+        #expect(viewState.navigationTitle == "Loaded Article")
+
+        state.applyNavigationFinished()
+        viewState = state.derivedViewState()
+        #expect(viewState.phase == .loaded)
+        #expect(viewState.loadingProgress == 1)
+
+        state.applyNavigationFailure("The page could not be loaded.")
+        viewState = state.derivedViewState()
+        #expect(viewState.phase == .failed("The page could not be loaded."))
+    }
+
+    @Test
     func articlesScreenStateStartsWithoutSelectionPlaceholder() {
         let state = ArticlesScreenState()
 

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1538,6 +1538,23 @@ struct RSSReaderTests {
     }
 
     @Test
+    func webViewScreenStateEnqueuesAndAcknowledgesReloadCommand() {
+        let route = ArticleWebViewRoute(
+            articleID: UUID(),
+            url: URL(string: "https://example.com/articles/webview-state-reload")!
+        )
+        var state = WebViewScreenState(route: route)
+
+        state.enqueueReloadCommand()
+        let pendingCommand = try! #require(state.derivedViewState().pendingCommand)
+        #expect(pendingCommand.kind == .reload)
+
+        state.acknowledgeCommand(pendingCommand)
+
+        #expect(state.derivedViewState().pendingCommand == nil)
+    }
+
+    @Test
     func webViewScreenStateStartsInFailurePhaseForUnsupportedInitialURL() {
         let route = ArticleWebViewRoute(
             articleID: UUID(),
@@ -1555,6 +1572,24 @@ struct RSSReaderTests {
         #expect(viewState.toolbar.isShareEnabled == false)
         #expect(viewState.bottomActions.openExternalBrowserURL == nil)
         #expect(viewState.bottomActions.isOpenExternalBrowserEnabled == false)
+        #expect(viewState.pendingCommand == nil)
+    }
+
+    @Test
+    func webViewScreenControllerBridgesReloadCommandWithoutKeepingItInViewStateForever() {
+        let route = ArticleWebViewRoute(
+            articleID: UUID(),
+            url: URL(string: "https://example.com/articles/webview-controller-reload")!
+        )
+        let controller = WebViewScreenController(route: route)
+
+        controller.reloadPage()
+        let pendingCommand = try! #require(controller.screenState.derivedViewState().pendingCommand)
+        #expect(pendingCommand.kind == .reload)
+
+        controller.handleCommandExecution(pendingCommand)
+
+        #expect(controller.screenState.derivedViewState().pendingCommand == nil)
     }
 
     @Test

--- a/RSSReaderTests/RSSReaderTests.swift
+++ b/RSSReaderTests/RSSReaderTests.swift
@@ -1540,6 +1540,32 @@ struct RSSReaderTests {
     }
 
     @Test
+    func webViewScreenStateSwitchesShareAndBrowserActionsToCurrentPageURL() {
+        let route = ArticleWebViewRoute(
+            articleID: UUID(),
+            url: URL(string: "https://example.com/articles/original")!
+        )
+        var state = WebViewScreenState(route: route)
+
+        state.applyCurrentPageURL(URL(string: "https://example.com/articles/redirected")!)
+
+        var viewState = state.derivedViewState()
+        #expect(viewState.toolbar.shareURL?.absoluteString == "https://example.com/articles/redirected")
+        #expect(
+            viewState.bottomActions.openExternalBrowserURL?.absoluteString
+                == "https://example.com/articles/redirected"
+        )
+
+        state.applyCurrentPageURL(URL(string: "mailto:hello@example.com")!)
+
+        viewState = state.derivedViewState()
+        #expect(viewState.toolbar.shareURL == nil)
+        #expect(viewState.toolbar.isShareEnabled == false)
+        #expect(viewState.bottomActions.openExternalBrowserURL == nil)
+        #expect(viewState.bottomActions.isOpenExternalBrowserEnabled == false)
+    }
+
+    @Test
     func webViewScreenStateIncrementsReloadRevisionOnlyForSupportedURLs() {
         let supportedRoute = ArticleWebViewRoute(
             articleID: UUID(),


### PR DESCRIPTION
## Кратко
Задача WebView Screen выполнена

Реализовано:
- [x] определить app-level navigation flow для `WebView Screen`: `RootView` должен уметь переключать detail между `Article Screen` и `WebView Screen` по `ReadingDetailRoute.webView`, а закрытие web view должно возвращать пользователя к текущей статье;
- [x] создать отдельный `WebView Screen` на базе `WKWebView` для `articleURL`, чтобы экран получал уже подготовленный `ArticleWebViewRoute` и не знал о shell-роутинге напрямую;
- [x] определить screen-level state/model для `WebView Screen`, чтобы отделить `initialURL`, loading progress, navigation title, share action availability и error state от SwiftUI `View`;
- [x] реализовать загрузку `articleURL` в `WKWebView` с базовым loading state для первого открытия страницы;
- [x] реализовать error / fallback UX, если `articleURL` невалиден или страница не открывается, с явным сценарием возврата назад к статье;
- [x] добавить toolbar-кнопку `share` в правой части top bar и связать её с canonical `articleURL` / текущим `ArticleWebViewRoute.url`;
- [x] поддержать `defaultReaderMode` из `AppSettings` как policy initial presentation для `WebView Screen`;
- [x] добавить нижний action `open in external browser` в `bottomBar`;
- [x] реализовать единственный кастомный gesture `left-edge swipe to close`: edge swipe от левого края закрывает `WebView Screen` и возвращает пользователя в `Article Screen`, а встроенный history navigation внутри `WKWebView` отключён, чтобы жест не конфликтовал с поведением страницы;
- [x] добавить нижний action `refresh` в левой части `bottomBar` и связать его с перезагрузкой текущей страницы в `WKWebView` без возврата к общему `command bridge`;
- [x] синхронизировать `current page URL` с `WebView Screen` state, чтобы `share` и `open in external browser` использовали фактический адрес текущей открытой страницы, а не только исходный `ArticleWebViewRoute.url`;
- [x] привести loading presentation `WebView Screen` к тому же UI pattern, что и у `Article Screen`, чтобы первичная загрузка выглядела консистентно на уровне приложения;
- [x] скрывать browser actions (`share`, `refresh`, `open in external browser`) в loading/error состояниях `WebView Screen`, чтобы toolbar и `bottomBar` не предлагали действия над ещё не открытой или недоступной страницей;
- [x] провести `cleanup` `WebViewScreenView`: выделить секции/подвью, добавить `MARK` и упростить чтение `WKWebView` bridge-слоя без изменения поведения экрана.

## Закрывает
Closes #135 
Closes #136 
Closes #137 
Closes #138 
Closes #139 
Closes #306 
Closes #307 
Closes #309 
Closes #310 
Closes #311 
Closes #312 
Closes #315 
Closes #316 
Closes #317 
Closes #318 
Closes #319 
Closes #134  