### PR TITLE
Background Refresh Hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,8 +414,10 @@
 - [x] покрыть tests-ами validation observability layer: добавлен отдельный infrastructure-level suite для registration marker, runtime prerequisites snapshot и diagnostics reporter contract, чтобы observability-поведение проверялось напрямую, а не только как побочный эффект существующих scheduler / execution orchestration tests.
 
 #### Background Refresh Hardening
-- [ ] провести cleanup / refactor background refresh-related кода после введения validation observability: выровнять границы между scheduler, execution adapter, runtime prerequisites source, `BackgroundRefreshService`, app lifecycle wiring и screen reload helpers, а также убрать временные debug hooks, если они больше не нужны;
-- [ ] сузить `Background Refresh` diagnostics surface до устойчивого app-level contract: после добавления observability убрать дублирующие или слишком низкоуровневые markers и убедиться, что app-level reload boundary между `remote sync reload` и `background refresh reload` не деградировала.
+- [x] провести cleanup / refactor background refresh-related кода после введения validation observability: app lifecycle wiring больше не собирает registration / launch scheduling / execution вручную через top-level helpers и legacy app-level markers; `RSSReaderApp` и `AppComposition` делегируют эти app-level входы в `AppDependencies`, где сходятся `BackgroundRefreshService`, execution coordinator, scheduler и validation diagnostics reporter, а временные debug hooks в launch scheduling path удалены;
+- [ ] убрать legacy app-level launch scheduling markers, которые дублируют новый validation reporter: после появления `BackgroundRefreshValidationDiagnosticsReporter` `AppComposition` не должен публиковать второй параллельный app-level contract для launch scheduling failures и duplicate-launch skips;
+- [ ] сузить `Background Refresh` diagnostics surface до устойчивого app-level contract: решить, какие scheduler / service-level logs остаются внутренними technical traces, а какие больше не нужны после введения observability layer, чтобы validation опирался на один канонический набор markers;
+- [ ] после cleanup diagnostics проверить, что app-level reload boundary между `remote sync reload` и `background refresh reload` не деградировала и не замаскирована новыми hardening-правками.
 
 ### Deferred Validation
 #### Sync Real-Device Validation Kit

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@
 #### Background Refresh Hardening
 - [x] провести cleanup / refactor background refresh-related кода после введения validation observability: app lifecycle wiring больше не собирает registration / launch scheduling / execution вручную через top-level helpers и legacy app-level markers; `RSSReaderApp` и `AppComposition` делегируют эти app-level входы в `AppDependencies`, где сходятся `BackgroundRefreshService`, execution coordinator, scheduler и validation diagnostics reporter, а временные debug hooks в launch scheduling path удалены;
 - [x] сузить `Background Refresh` diagnostics surface до устойчивого app-level contract: `BackgroundRefreshValidationDiagnosticsReporter` оставлен единственным каноническим набором validation markers, а scheduler / `BackgroundRefreshService` / app-level wrappers вокруг них переведены на `debug`-only internal traces с явными `... trace ...` префиксами, чтобы validation не опирался на второй конкурирующий набор логов;
-- [ ] после cleanup diagnostics проверить, что app-level reload boundary между `remote sync reload` и `background refresh reload` не деградировала и не замаскирована новыми hardening-правками.
+- [x] после cleanup diagnostics проверить, что app-level reload boundary между `remote sync reload` и `background refresh reload` не деградировала и не замаскирована новыми hardening-правками: добавлен сквозной test, который поднимает оба app-level пути на одном `AppState` и подтверждает, что foreground handoff path продолжает выставлять `backgroundRefresh`, а CloudKit / persistent store correlation path продолжает выставлять `remoteSyncImport`, не схлопывая оба reload-сигнала в один flow.
 
 ### Deferred Validation
 #### Sync Real-Device Validation Kit

--- a/README.md
+++ b/README.md
@@ -415,8 +415,7 @@
 
 #### Background Refresh Hardening
 - [x] провести cleanup / refactor background refresh-related кода после введения validation observability: app lifecycle wiring больше не собирает registration / launch scheduling / execution вручную через top-level helpers и legacy app-level markers; `RSSReaderApp` и `AppComposition` делегируют эти app-level входы в `AppDependencies`, где сходятся `BackgroundRefreshService`, execution coordinator, scheduler и validation diagnostics reporter, а временные debug hooks в launch scheduling path удалены;
-- [ ] убрать legacy app-level launch scheduling markers, которые дублируют новый validation reporter: после появления `BackgroundRefreshValidationDiagnosticsReporter` `AppComposition` не должен публиковать второй параллельный app-level contract для launch scheduling failures и duplicate-launch skips;
-- [ ] сузить `Background Refresh` diagnostics surface до устойчивого app-level contract: решить, какие scheduler / service-level logs остаются внутренними technical traces, а какие больше не нужны после введения observability layer, чтобы validation опирался на один канонический набор markers;
+- [x] сузить `Background Refresh` diagnostics surface до устойчивого app-level contract: `BackgroundRefreshValidationDiagnosticsReporter` оставлен единственным каноническим набором validation markers, а scheduler / `BackgroundRefreshService` / app-level wrappers вокруг них переведены на `debug`-only internal traces с явными `... trace ...` префиксами, чтобы validation не опирался на второй конкурирующий набор логов;
 - [ ] после cleanup diagnostics проверить, что app-level reload boundary между `remote sync reload` и `background refresh reload` не деградировала и не замаскирована новыми hardening-правками.
 
 ### Deferred Validation

--- a/RSSReader/Infrastructure/AppComposition.swift
+++ b/RSSReader/Infrastructure/AppComposition.swift
@@ -94,43 +94,7 @@ enum AppComposition {
 
     @MainActor
     static func scheduleBackgroundRefreshOnLaunch(using dependencies: AppDependencies) {
-        do {
-            let result = try dependencies.replaceBackgroundRefreshSchedule()
-            switch result {
-            case .scheduled(let plan):
-                dependencies.backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
-                    outcome: .scheduled,
-                    identifier: plan.identifier,
-                    earliestBeginDate: plan.earliestBeginDate,
-                    failureReason: nil
-                )
-            case .cancelled:
-                dependencies.backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
-                    outcome: .cancelled,
-                    identifier: nil,
-                    earliestBeginDate: nil,
-                    failureReason: nil
-                )
-            case nil:
-                dependencies.backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
-                    outcome: .unavailable,
-                    identifier: nil,
-                    earliestBeginDate: nil,
-                    failureReason: nil
-                )
-            }
-        } catch {
-            let failureReason = BackgroundRefreshScheduleFailureReason.classify(error).rawValue
-            dependencies.backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
-                outcome: .failed,
-                identifier: nil,
-                earliestBeginDate: nil,
-                failureReason: BackgroundRefreshScheduleFailureReason.classify(error)
-            )
-            dependencies.logger.error(
-                "Failed to configure background refresh schedule on app launch: reason=\(failureReason) error=\(error)"
-            )
-        }
+        dependencies.configureBackgroundRefreshLaunchScheduling()
     }
 
     @MainActor
@@ -149,15 +113,7 @@ enum AppComposition {
         guard bootstrapGuard: AppLaunchBootstrapGuard
     ) {
         guard bootstrapGuard.beginAttempt(identifier: "BackgroundRefreshLaunchScheduling") else {
-            dependencies.backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
-                outcome: .skippedDuplicateLaunchAttempt,
-                identifier: nil,
-                earliestBeginDate: nil,
-                failureReason: nil
-            )
-            dependencies.logger.debug(
-                "Skipped background refresh launch scheduling because app launch guard already attempted it"
-            )
+            dependencies.reportSkippedDuplicateBackgroundRefreshLaunchSchedulingAttempt()
             return
         }
 

--- a/RSSReader/Infrastructure/AppDependencies.swift
+++ b/RSSReader/Infrastructure/AppDependencies.swift
@@ -535,6 +535,23 @@ extension AppDependencies {
 
 extension AppDependencies {
     @MainActor
+    func reportBackgroundRefreshRegistrationConfigured(
+        identifier: String = BackgroundRefreshTaskConfiguration.appRefreshIdentifier,
+        handlerDescription: String = "SwiftUI.backgroundTask(.appRefresh)"
+    ) {
+        backgroundRefreshValidationDiagnosticsReporter.reportRegistrationConfigured(
+            identifier: identifier,
+            handlerDescription: handlerDescription
+        )
+    }
+
+    @MainActor
+    func executeBackgroundAppRefresh() async -> BackgroundRefreshExecutionOutcome {
+        let executionCoordinator = DefaultBackgroundRefreshExecutionCoordinator(dependencies: self)
+        return await executionCoordinator.executeAppRefresh()
+    }
+
+    @MainActor
     func startSyncCoordinatorAppLifetime() {
         syncRuntimeOrchestrator.startSyncCoordinatorAppLifetime()
     }
@@ -1096,6 +1113,32 @@ extension AppDependencies {
     }
 
     @MainActor
+    func configureBackgroundRefreshLaunchScheduling(now: Date = .now) {
+        do {
+            reportBackgroundRefreshLaunchScheduling(
+                try replaceBackgroundRefreshSchedule(now: now)
+            )
+        } catch {
+            backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
+                outcome: .failed,
+                identifier: nil,
+                earliestBeginDate: nil,
+                failureReason: BackgroundRefreshScheduleFailureReason.classify(error)
+            )
+        }
+    }
+
+    @MainActor
+    func reportSkippedDuplicateBackgroundRefreshLaunchSchedulingAttempt() {
+        backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
+            outcome: .skippedDuplicateLaunchAttempt,
+            identifier: nil,
+            earliestBeginDate: nil,
+            failureReason: nil
+        )
+    }
+
+    @MainActor
     @discardableResult
     func replaceBackgroundRefreshSchedule(
         using configuration: BackgroundRefreshConfiguration,
@@ -1120,6 +1163,33 @@ extension AppDependencies {
 }
 
 private extension AppDependencies {
+    @MainActor
+    func reportBackgroundRefreshLaunchScheduling(_ result: BackgroundRefreshScheduleResult?) {
+        switch result {
+        case .scheduled(let plan):
+            backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
+                outcome: .scheduled,
+                identifier: plan.identifier,
+                earliestBeginDate: plan.earliestBeginDate,
+                failureReason: nil
+            )
+        case .cancelled:
+            backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
+                outcome: .cancelled,
+                identifier: nil,
+                earliestBeginDate: nil,
+                failureReason: nil
+            )
+        case nil:
+            backgroundRefreshValidationDiagnosticsReporter.reportLaunchScheduling(
+                outcome: .unavailable,
+                identifier: nil,
+                earliestBeginDate: nil,
+                failureReason: nil
+            )
+        }
+    }
+
     @MainActor
     func shouldPresentSelectedArticleInWebViewByDefault() -> Bool {
         guard let appSettingsService else {

--- a/RSSReader/Infrastructure/AppDependencies.swift
+++ b/RSSReader/Infrastructure/AppDependencies.swift
@@ -1095,7 +1095,9 @@ extension AppDependencies {
     @MainActor
     func refreshFeedsForBackground() async -> BackgroundRefreshServiceExecutionResult {
         guard let backgroundRefreshService else {
-            logger.error("Background refresh service is unavailable")
+            logger.debug(
+                "Background refresh dependencies trace outcome=serviceUnavailable operation=executeBackgroundAppRefresh"
+            )
             return .failedToStart(.feedRefreshServiceUnavailable)
         }
 
@@ -1153,7 +1155,9 @@ extension AppDependencies {
         now: Date = .now
     ) throws -> BackgroundRefreshScheduleResult? {
         guard let backgroundRefreshService else {
-            logger.error("Background refresh service is unavailable for schedule replacement")
+            logger.debug(
+                "Background refresh dependencies trace outcome=serviceUnavailable operation=replaceSchedule"
+            )
             return nil
         }
 

--- a/RSSReader/Infrastructure/BackgroundRefreshScheduler.swift
+++ b/RSSReader/Infrastructure/BackgroundRefreshScheduler.swift
@@ -90,7 +90,9 @@ final class DefaultBackgroundRefreshScheduler: BackgroundRefreshScheduling {
             now: now,
             taskIdentifier: taskIdentifier
         ) else {
-            logger.info("Skipped scheduling background app refresh because refreshIntervalPreference is manual")
+            logger.debug(
+                "Background refresh scheduler trace outcome=skippedManual identifier=\(taskIdentifier)"
+            )
             return nil
         }
 
@@ -99,13 +101,13 @@ final class DefaultBackgroundRefreshScheduler: BackgroundRefreshScheduling {
 
         do {
             try taskScheduler.submit(request)
-            logger.info(
-                "Scheduled background app refresh request identifier=\(plan.identifier) earliestBeginDate=\(plan.earliestBeginDate)"
+            logger.debug(
+                "Background refresh scheduler trace outcome=scheduled identifier=\(plan.identifier) earliestBeginDate=\(plan.earliestBeginDate)"
             )
             return plan
         } catch {
-            logger.error(
-                "Failed to schedule background app refresh request identifier=\(plan.identifier) earliestBeginDate=\(plan.earliestBeginDate) error=\(error)"
+            logger.debug(
+                "Background refresh scheduler trace outcome=failed identifier=\(plan.identifier) earliestBeginDate=\(plan.earliestBeginDate) error=\(error)"
             )
             throw error
         }
@@ -113,7 +115,7 @@ final class DefaultBackgroundRefreshScheduler: BackgroundRefreshScheduling {
 
     func cancel() {
         taskScheduler.cancel(taskRequestWithIdentifier: taskIdentifier)
-        logger.info("Cancelled background app refresh request identifier=\(taskIdentifier)")
+        logger.debug("Background refresh scheduler trace outcome=cancelled identifier=\(taskIdentifier)")
     }
 
     @discardableResult

--- a/RSSReader/RSSReaderApp.swift
+++ b/RSSReader/RSSReaderApp.swift
@@ -1,22 +1,5 @@
 import SwiftUI
 
-@MainActor
-func performBackgroundAppRefresh(using dependencies: AppDependencies) async -> BackgroundRefreshExecutionOutcome {
-    let executionCoordinator = DefaultBackgroundRefreshExecutionCoordinator(dependencies: dependencies)
-    return await executionCoordinator.executeAppRefresh()
-}
-
-@MainActor
-func reportBackgroundRefreshRegistration(
-    using dependencies: AppDependencies,
-    identifier: String = BackgroundRefreshTaskConfiguration.appRefreshIdentifier
-) {
-    dependencies.backgroundRefreshValidationDiagnosticsReporter.reportRegistrationConfigured(
-        identifier: identifier,
-        handlerDescription: "SwiftUI.backgroundTask(.appRefresh)"
-    )
-}
-
 @main
 struct RSSReaderApp: App {
     static let backgroundAppRefreshIdentifier = BackgroundRefreshTaskConfiguration.appRefreshIdentifier
@@ -27,7 +10,7 @@ struct RSSReaderApp: App {
     init() {
         let dependencies = AppComposition.makeAppDependencies()
         self.dependencies = dependencies
-        reportBackgroundRefreshRegistration(using: dependencies)
+        dependencies.reportBackgroundRefreshRegistrationConfigured()
     }
 
     var body: some Scene {
@@ -35,7 +18,7 @@ struct RSSReaderApp: App {
             AppComposition.makeRoot(dependencies: dependencies)
         }
         .backgroundTask(.appRefresh(Self.backgroundAppRefreshIdentifier)) {
-            _ = await performBackgroundAppRefresh(using: dependencies)
+            _ = await dependencies.executeBackgroundAppRefresh()
         }
     }
 }

--- a/RSSReader/Services/Feeds/BackgroundRefreshService.swift
+++ b/RSSReader/Services/Feeds/BackgroundRefreshService.swift
@@ -90,17 +90,17 @@ final class DefaultBackgroundRefreshService: BackgroundRefreshService {
         do {
             configuration = try loadConfiguration()
         } catch {
-            logger.error("Failed to load background refresh configuration: \(error)")
+            logger.debug("Background refresh service trace outcome=configurationLoadFailed error=\(error)")
             return .failedToStart(.configurationLoadFailed)
         }
 
         guard configuration.policy.isAutomaticRefreshEnabled else {
-            logger.info("Skipped background refresh because refreshIntervalPreference is manual")
+            logger.debug("Background refresh service trace outcome=skippedManual")
             return .skippedManual(configuration)
         }
 
         guard let feedRefreshService else {
-            logger.error("Feed refresh service is unavailable for background refresh execution")
+            logger.debug("Background refresh service trace outcome=feedRefreshServiceUnavailable")
             return .failedToStart(.feedRefreshServiceUnavailable)
         }
 

--- a/RSSReaderTests/Infrastructure/AppDependenciesTests.swift
+++ b/RSSReaderTests/Infrastructure/AppDependenciesTests.swift
@@ -977,6 +977,72 @@ struct AppDependenciesTests {
     }
 
     @Test
+    func appLevelReloadBoundaryKeepsRemoteSyncAndBackgroundRefreshTriggersSeparateAfterDiagnosticsCleanup() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let syncCoordinator = SyncCoordinator(isSyncEnabled: true)
+        syncCoordinator.applyAccountAvailability(.available)
+        let cloudKitRuntimeEventSource = TestCloudKitRuntimeEventSource()
+        let remoteChangeSource = TestPersistentStoreRemoteChangeSource()
+        let backgroundRefreshHandoffCoordinator = RecordingBackgroundRefreshForegroundHandoffCoordinator()
+        let dependencies = AppDependencies(
+            logger: TestLogger(),
+            httpClient: harness.httpClient,
+            modelContainer: harness.modelContainer,
+            syncBackedStoreReference: testSyncBackedStoreReference(),
+            backgroundRefreshForegroundHandoffCoordinator: backgroundRefreshHandoffCoordinator,
+            cloudKitRuntimeEventSource: cloudKitRuntimeEventSource,
+            persistentStoreRemoteChangeSource: remoteChangeSource,
+            syncCoordinator: syncCoordinator
+        )
+        let appState = AppState()
+        let initialSidebarReloadID = appState.sourcesSidebarReloadID
+        let initialArticleListReloadID = appState.articleListReloadID
+        let initialArticleScreenReloadID = appState.articleScreenReloadID
+
+        AppComposition.bindBackgroundRefreshForegroundReloadHandler(
+            using: dependencies,
+            appState: appState
+        )
+        dependencies.startRemoteSyncReloadAppLifetime(using: appState)
+
+        backgroundRefreshHandoffCoordinator.triggerBoundReloadHandler()
+
+        #expect(appState.lastContentReloadTrigger == .backgroundRefresh)
+        #expect(appState.sourcesSidebarReloadID != initialSidebarReloadID)
+        #expect(appState.articleListReloadID != initialArticleListReloadID)
+        #expect(appState.articleScreenReloadID != initialArticleScreenReloadID)
+
+        let backgroundRefreshSidebarReloadID = appState.sourcesSidebarReloadID
+        let backgroundRefreshArticleListReloadID = appState.articleListReloadID
+        let backgroundRefreshArticleScreenReloadID = appState.articleScreenReloadID
+
+        await remoteChangeSource.yield(
+            PersistentStoreRemoteChangeEvent(
+                storeUUID: "SyncBackedStore",
+                storeURL: URL(string: "file:///tmp/SyncBackedStore.sqlite")
+            )
+        )
+        await cloudKitRuntimeEventSource.yield(
+            .finished(
+                .import,
+                CloudKitRuntimeEventContext(
+                    identifier: UUID(),
+                    storeIdentifier: "SyncBackedStore",
+                    startDate: .distantPast,
+                    endDate: .now
+                )
+            )
+        )
+
+        try await expectEventually {
+            appState.lastContentReloadTrigger == .remoteSyncImport
+                && appState.sourcesSidebarReloadID != backgroundRefreshSidebarReloadID
+                && appState.articleListReloadID != backgroundRefreshArticleListReloadID
+                && appState.articleScreenReloadID != backgroundRefreshArticleScreenReloadID
+        }
+    }
+
+    @Test
     func appDependenciesStopSyncRuntimeAppLifetimeCancelsRemoteReloadObservation() async throws {
         let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
         let syncCoordinator = SyncCoordinator(isSyncEnabled: true)
@@ -1067,6 +1133,29 @@ private actor TestICloudAccountAvailabilityService: ICloudAccountAvailabilitySer
 
     func yield(_ availability: ICloudAccountAvailability) {
         continuation.yield(availability)
+    }
+}
+
+@MainActor
+private final class RecordingBackgroundRefreshForegroundHandoffCoordinator:
+    BackgroundRefreshForegroundHandoffCoordinating
+{
+    private var reloadHandler: (@MainActor () -> Void)?
+
+    func bindReloadHandler(_ handler: @escaping @MainActor () -> Void) {
+        reloadHandler = handler
+    }
+
+    func unbindReloadHandler() {
+        reloadHandler = nil
+    }
+
+    func updateRuntimeState(_ runtimeState: AppRuntimeReloadState) {}
+
+    func handleBackgroundRefreshExecutionOutcome(_ outcome: BackgroundRefreshExecutionOutcome) {}
+
+    func triggerBoundReloadHandler() {
+        reloadHandler?()
     }
 }
 

--- a/RSSReaderTests/Infrastructure/BackgroundRefreshPolicyIntegrationTests.swift
+++ b/RSSReaderTests/Infrastructure/BackgroundRefreshPolicyIntegrationTests.swift
@@ -71,8 +71,8 @@ struct BackgroundRefreshPolicyIntegrationTests {
         #expect(recordingScheduler.lastReplacedConfiguration == nil)
         #expect(
             logger.contains(
-                "Background refresh service is unavailable for schedule replacement",
-                level: .error
+                "Background refresh dependencies trace outcome=serviceUnavailable operation=replaceSchedule",
+                level: .debug
             )
         )
     }

--- a/RSSReaderTests/Infrastructure/BackgroundRefreshSchedulerTests.swift
+++ b/RSSReaderTests/Infrastructure/BackgroundRefreshSchedulerTests.swift
@@ -63,8 +63,8 @@ struct BackgroundRefreshSchedulerTests {
         #expect(request.earliestBeginDate == now.addingTimeInterval(6 * 60 * 60))
         #expect(
             logger.contains(
-                "Scheduled background app refresh request identifier=\(BackgroundRefreshTaskConfiguration.appRefreshIdentifier)",
-                level: .info
+                "Background refresh scheduler trace outcome=scheduled identifier=\(BackgroundRefreshTaskConfiguration.appRefreshIdentifier)",
+                level: .debug
             )
         )
     }
@@ -91,8 +91,8 @@ struct BackgroundRefreshSchedulerTests {
         #expect(taskScheduler.submittedAppRefreshRequests.isEmpty)
         #expect(
             logger.contains(
-                "Skipped scheduling background app refresh because refreshIntervalPreference is manual",
-                level: .info
+                "Background refresh scheduler trace outcome=skippedManual identifier=\(BackgroundRefreshTaskConfiguration.appRefreshIdentifier)",
+                level: .debug
             )
         )
     }

--- a/RSSReaderTests/Infrastructure/BackgroundRefreshValidationObservabilityTests.swift
+++ b/RSSReaderTests/Infrastructure/BackgroundRefreshValidationObservabilityTests.swift
@@ -11,7 +11,7 @@ struct BackgroundRefreshValidationObservabilityTests {
         let logger = RecordingLogger()
         let dependencies = AppDependencies(logger: logger)
 
-        reportBackgroundRefreshRegistration(using: dependencies)
+        dependencies.reportBackgroundRefreshRegistrationConfigured()
 
         #expect(
             dependencies.currentBackgroundRefreshValidationDiagnostics().registration

--- a/RSSReaderTests/Infrastructure/RSSReaderAppTests.swift
+++ b/RSSReaderTests/Infrastructure/RSSReaderAppTests.swift
@@ -18,7 +18,7 @@ struct RSSReaderAppTests {
         let logger = RecordingLogger()
         let dependencies = AppDependencies(logger: logger)
 
-        reportBackgroundRefreshRegistration(using: dependencies)
+        dependencies.reportBackgroundRefreshRegistrationConfigured()
 
         #expect(
             logger.contains(
@@ -65,7 +65,7 @@ struct RSSReaderAppTests {
             backgroundRefreshScheduler: scheduler
         )
 
-        let outcome = await performBackgroundAppRefresh(using: dependencies)
+        let outcome = await dependencies.executeBackgroundAppRefresh()
 
         #expect(backgroundRefreshService.performScheduledRefreshCallCount == 1)
         #expect(backgroundRefreshService.loadConfigurationCallCount == 1)


### PR DESCRIPTION
## Кратко
Задача Background Refresh Hardening выполнена

Реализовано:
- [x] провести cleanup / refactor background refresh-related кода после введения validation observability: app lifecycle wiring больше не собирает registration / launch scheduling / execution вручную через top-level helpers и legacy app-level markers; `RSSReaderApp` и `AppComposition` делегируют эти app-level входы в `AppDependencies`, где сходятся `BackgroundRefreshService`, execution coordinator, scheduler и validation diagnostics reporter, а временные debug hooks в launch scheduling path удалены;
- [x] сузить `Background Refresh` diagnostics surface до устойчивого app-level contract: `BackgroundRefreshValidationDiagnosticsReporter` оставлен единственным каноническим набором validation markers, а scheduler / `BackgroundRefreshService` / app-level wrappers вокруг них переведены на `debug`-only internal traces с явными `... trace ...` префиксами, чтобы validation не опирался на второй конкурирующий набор логов;
- [x] после cleanup diagnostics проверить, что app-level reload boundary между `remote sync reload` и `background refresh reload` не деградировала и не замаскирована новыми hardening-правками: добавлен сквозной test, который поднимает оба app-level пути на одном `AppState` и подтверждает, что foreground handoff path продолжает выставлять `backgroundRefresh`, а CloudKit / persistent store correlation path продолжает выставлять `remoteSyncImport`, не схлопывая оба reload-сигнала в один flow.

## Закрывает
Closes #399 
Closes #469 
Closes #470 
Closes #390 