### PR TITLE
Feed Input And Parsing Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@
 - [x] `Feed XML Document Builder Tests`: покрыть `FeedXMLDocumentBuilder` / `FeedXMLDocument` контракт: empty document, malformed XML diagnostics с line/column, CDATA, attributes, namespace / qualified names и поиск child/nested text;
 - [x] `Feed Kind Detection Tests`: добавить unit tests для `FeedKindDetection`: RSS, Atom, unknown root, namespace-qualified feeds и unsupported feed kind diagnostics;
 - [x] `RSS Parser Fixture Tests`: покрыть `FeedRSSParser` fixtures для channel metadata, `item` payloads, `content:encoded`, `dc:creator`, `dc:date`, enclosure image URL и missing `channel` diagnostics;
-- [ ] `Atom Parser Fixture Tests`: покрыть `FeedAtomParser` fixtures для feed metadata, `entry` payloads, `alternate` / `self` / `enclosure` links, feed-level author fallback, `content` vs `summary` и missing `feed` diagnostics;
+- [x] `Atom Parser Fixture Tests`: покрыть `FeedAtomParser` fixtures для feed metadata, `entry` payloads, `alternate` / `self` / `enclosure` links, feed-level author fallback, `content` vs `summary` и missing `feed` diagnostics;
 - [ ] `Feed Entry Filtering Diagnostics Tests`: добавить unit tests для `FeedEntryFilteringService`: rejection reasons `missingExternalID`, `missingReadablePayload`, `missingUsefulReference`, сохранение порядка valid entries и diagnostic payload для rejected entries.
 
 #### Article Identity And Query Tests

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@
 #### Feed Input And Parsing Tests
 - [x] `Feed Date Parsing Matrix Tests`: добавить focused unit tests для `FeedDateParsingService`: ISO8601 с fractional seconds и без них, RSS/RFC822 варианты с одно- и двузначным днём, timezone offsets, fallback formats, пустые и невалидные строки;
 - [x] `Feed XML Document Builder Tests`: покрыть `FeedXMLDocumentBuilder` / `FeedXMLDocument` контракт: empty document, malformed XML diagnostics с line/column, CDATA, attributes, namespace / qualified names и поиск child/nested text;
-- [ ] `Feed Kind Detection Tests`: добавить unit tests для `FeedKindDetection`: RSS, Atom, unknown root, namespace-qualified feeds и unsupported feed kind diagnostics;
+- [x] `Feed Kind Detection Tests`: добавить unit tests для `FeedKindDetection`: RSS, Atom, unknown root, namespace-qualified feeds и unsupported feed kind diagnostics;
 - [ ] `RSS Parser Fixture Tests`: покрыть `FeedRSSParser` fixtures для channel metadata, `item` payloads, `content:encoded`, `dc:creator`, `dc:date`, enclosure image URL и missing `channel` diagnostics;
 - [ ] `Atom Parser Fixture Tests`: покрыть `FeedAtomParser` fixtures для feed metadata, `entry` payloads, `alternate` / `self` / `enclosure` links, feed-level author fallback, `content` vs `summary` и missing `feed` diagnostics;
 - [ ] `Feed Entry Filtering Diagnostics Tests`: добавить unit tests для `FeedEntryFilteringService`: rejection reasons `missingExternalID`, `missingReadablePayload`, `missingUsefulReference`, сохранение порядка valid entries и diagnostic payload для rejected entries.

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@
 - [x] `Feed Date Parsing Matrix Tests`: добавить focused unit tests для `FeedDateParsingService`: ISO8601 с fractional seconds и без них, RSS/RFC822 варианты с одно- и двузначным днём, timezone offsets, fallback formats, пустые и невалидные строки;
 - [x] `Feed XML Document Builder Tests`: покрыть `FeedXMLDocumentBuilder` / `FeedXMLDocument` контракт: empty document, malformed XML diagnostics с line/column, CDATA, attributes, namespace / qualified names и поиск child/nested text;
 - [x] `Feed Kind Detection Tests`: добавить unit tests для `FeedKindDetection`: RSS, Atom, unknown root, namespace-qualified feeds и unsupported feed kind diagnostics;
-- [ ] `RSS Parser Fixture Tests`: покрыть `FeedRSSParser` fixtures для channel metadata, `item` payloads, `content:encoded`, `dc:creator`, `dc:date`, enclosure image URL и missing `channel` diagnostics;
+- [x] `RSS Parser Fixture Tests`: покрыть `FeedRSSParser` fixtures для channel metadata, `item` payloads, `content:encoded`, `dc:creator`, `dc:date`, enclosure image URL и missing `channel` diagnostics;
 - [ ] `Atom Parser Fixture Tests`: покрыть `FeedAtomParser` fixtures для feed metadata, `entry` payloads, `alternate` / `self` / `enclosure` links, feed-level author fallback, `content` vs `summary` и missing `feed` diagnostics;
 - [ ] `Feed Entry Filtering Diagnostics Tests`: добавить unit tests для `FeedEntryFilteringService`: rejection reasons `missingExternalID`, `missingReadablePayload`, `missingUsefulReference`, сохранение порядка valid entries и diagnostic payload для rejected entries.
 

--- a/README.md
+++ b/README.md
@@ -547,8 +547,8 @@
 - [x] `Residual Large Test Suite Split`: проверить и физически разделить оставшиеся крупные focused suites (`ArticleScreenContentRendererTests`, `BackgroundRefreshExecutionCoordinatorTests`, `AppDependenciesRemoteSyncReloadTests`, `SourceManagementScreenStateTests`, `SettingsScreenPresentationTests`) на подфайлы по behavior groups / shared doubles, если это можно сделать без изменения тестового смысла.
 
 #### Feed Input And Parsing Tests
-- [ ] `Feed Date Parsing Matrix Tests`: добавить focused unit tests для `FeedDateParsingService`: ISO8601 с fractional seconds и без них, RSS/RFC822 варианты с одно- и двузначным днём, timezone offsets, fallback formats, пустые и невалидные строки;
-- [ ] `Feed XML Document Builder Tests`: покрыть `FeedXMLDocumentBuilder` / `FeedXMLDocument` контракт: empty document, malformed XML diagnostics с line/column, CDATA, attributes, namespace / qualified names и поиск child/nested text;
+- [x] `Feed Date Parsing Matrix Tests`: добавить focused unit tests для `FeedDateParsingService`: ISO8601 с fractional seconds и без них, RSS/RFC822 варианты с одно- и двузначным днём, timezone offsets, fallback formats, пустые и невалидные строки;
+- [x] `Feed XML Document Builder Tests`: покрыть `FeedXMLDocumentBuilder` / `FeedXMLDocument` контракт: empty document, malformed XML diagnostics с line/column, CDATA, attributes, namespace / qualified names и поиск child/nested text;
 - [ ] `Feed Kind Detection Tests`: добавить unit tests для `FeedKindDetection`: RSS, Atom, unknown root, namespace-qualified feeds и unsupported feed kind diagnostics;
 - [ ] `RSS Parser Fixture Tests`: покрыть `FeedRSSParser` fixtures для channel metadata, `item` payloads, `content:encoded`, `dc:creator`, `dc:date`, enclosure image URL и missing `channel` diagnostics;
 - [ ] `Atom Parser Fixture Tests`: покрыть `FeedAtomParser` fixtures для feed metadata, `entry` payloads, `alternate` / `self` / `enclosure` links, feed-level author fallback, `content` vs `summary` и missing `feed` diagnostics;

--- a/README.md
+++ b/README.md
@@ -552,7 +552,7 @@
 - [x] `Feed Kind Detection Tests`: добавить unit tests для `FeedKindDetection`: RSS, Atom, unknown root, namespace-qualified feeds и unsupported feed kind diagnostics;
 - [x] `RSS Parser Fixture Tests`: покрыть `FeedRSSParser` fixtures для channel metadata, `item` payloads, `content:encoded`, `dc:creator`, `dc:date`, enclosure image URL и missing `channel` diagnostics;
 - [x] `Atom Parser Fixture Tests`: покрыть `FeedAtomParser` fixtures для feed metadata, `entry` payloads, `alternate` / `self` / `enclosure` links, feed-level author fallback, `content` vs `summary` и missing `feed` diagnostics;
-- [ ] `Feed Entry Filtering Diagnostics Tests`: добавить unit tests для `FeedEntryFilteringService`: rejection reasons `missingExternalID`, `missingReadablePayload`, `missingUsefulReference`, сохранение порядка valid entries и diagnostic payload для rejected entries.
+- [x] `Feed Entry Filtering Diagnostics Tests`: добавить unit tests для `FeedEntryFilteringService`: rejection reasons `missingExternalID`, `missingReadablePayload`, `missingUsefulReference`, сохранение порядка valid entries и diagnostic payload для rejected entries.
 
 #### Article Identity And Query Tests
 - [ ] `Article Identity Contract Tests`: покрыть `ArticleIdentityService` напрямую: приоритет `guid` → `canonicalURL` → `articleURL` → fallback hash, URL normalization, whitespace/title normalization, date normalization и стабильность external ID при эквивалентном input;

--- a/RSSReader/Services/Feeds/FeedRSSParser.swift
+++ b/RSSReader/Services/Feeds/FeedRSSParser.swift
@@ -57,7 +57,8 @@ extension FeedParserService {
                     ?? itemElement.firstChildText(named: "dc:creator")
                     ?? itemElement.firstChildText(named: "creator"),
                 publishedAtRaw: itemElement.firstChildText(named: "pubDate"),
-                updatedAtRaw: itemElement.firstChildText(named: "dc:date"),
+                updatedAtRaw: itemElement.firstChildText(named: "dc:date")
+                    ?? itemElement.firstChildText(named: "date"),
                 imageURL: rssEnclosureURL(in: itemElement)
             )
         }

--- a/RSSReader/Services/Feeds/FeedXMLDocumentBuilder.swift
+++ b/RSSReader/Services/Feeds/FeedXMLDocumentBuilder.swift
@@ -2,6 +2,14 @@ import Foundation
 
 extension FeedParserService {
     static func parse(_ data: Data) throws -> FeedXMLDocument {
+        let isWhitespaceOnly = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == true
+
+        if data.isEmpty || isWhitespaceOnly {
+            throw FeedParserError.emptyDocument
+        }
+
         let builder = FeedXMLTreeBuilder()
         let parser = XMLParser(data: data)
         parser.delegate = builder

--- a/RSSReaderTests/Feeds/FeedAtomParserTests.swift
+++ b/RSSReaderTests/Feeds/FeedAtomParserTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Feeds / Atom Parser")
+struct FeedAtomParserTests {
+    @Test
+    func parsesAtomMetadataEntryPayloadsAndLinksFromFixture() throws {
+        let parsedFeed = try FeedParserService.parseAtom(parseDocument(atomFixture))
+
+        #expect(parsedFeed.kind == .atom)
+        #expect(parsedFeed.metadata.title == "Example Atom Feed")
+        #expect(parsedFeed.metadata.subtitle == "Readable Atom subtitle")
+        #expect(parsedFeed.metadata.siteURL == "https://example.com/")
+        #expect(parsedFeed.metadata.iconURL == "https://example.com/icon.png")
+        #expect(parsedFeed.metadata.language == "en")
+
+        #expect(parsedFeed.entries.count == 2)
+
+        let firstEntry = try #require(parsedFeed.entries.first)
+        #expect(firstEntry.guid == "tag:example.com,2024:first")
+        #expect(firstEntry.url == "https://example.com/articles/1")
+        #expect(firstEntry.canonicalURL == "https://example.com/feed/entries/1")
+        #expect(firstEntry.title == "First Atom Article")
+        #expect(firstEntry.summary == "Short Atom summary")
+        #expect(firstEntry.contentHTML == "<p>Full Atom body</p>")
+        #expect(firstEntry.contentText == "<p>Full Atom body</p>")
+        #expect(firstEntry.author == "Entry Author")
+        #expect(firstEntry.publishedAtRaw == "2024-01-02T10:15:30Z")
+        #expect(firstEntry.updatedAtRaw == "2024-01-02T11:00:00Z")
+        #expect(firstEntry.imageURL == "https://example.com/images/atom-first.jpg")
+
+        let secondEntry = try #require(parsedFeed.entries.dropFirst().first)
+        #expect(secondEntry.guid == "tag:example.com,2024:second")
+        #expect(secondEntry.url == "https://example.com/articles/2")
+        #expect(secondEntry.canonicalURL == "https://example.com/feed/entries/2")
+        #expect(secondEntry.title == "Second Atom Article")
+        #expect(secondEntry.summary == "Only summary body")
+        #expect(secondEntry.contentHTML == "Only summary body")
+        #expect(secondEntry.contentText == "Only summary body")
+        #expect(secondEntry.author == "Feed Author")
+        #expect(secondEntry.imageURL == nil)
+    }
+
+    @Test
+    func missingFeedRootThrowsMissingAtomElementDiagnostic() throws {
+        let document = try parseDocument("""
+        <source xmlns="http://www.w3.org/2005/atom">
+          <title>Atom-like root without feed</title>
+        </source>
+        """)
+
+        do {
+            _ = try FeedParserService.extractAtomMetadata(from: document)
+            Issue.record("Expected missing feed to throw")
+        } catch FeedParserError.missingAtomElement(let elementName) {
+            #expect(elementName == "feed")
+        } catch {
+            Issue.record("Expected missing Atom element error, got \(error)")
+        }
+    }
+
+    private var atomFixture: String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/atom" xml:lang="en">
+          <title>Example Atom Feed</title>
+          <subtitle>Readable Atom subtitle</subtitle>
+          <link rel="self" href="https://example.com/feed.atom" />
+          <link rel="alternate" href=" https://example.com/ " />
+          <icon>https://example.com/icon.png</icon>
+          <author>
+            <name>Feed Author</name>
+          </author>
+          <entry>
+            <id>tag:example.com,2024:first</id>
+            <title>First Atom Article</title>
+            <link rel="alternate" href="https://example.com/articles/1" />
+            <link rel="self" href="https://example.com/feed/entries/1" />
+            <link rel="enclosure" type="image/jpeg" href=" https://example.com/images/atom-first.jpg " />
+            <summary>Short Atom summary</summary>
+            <content type="html"><![CDATA[<p>Full Atom body</p>]]></content>
+            <author>
+              <name>Entry Author</name>
+            </author>
+            <published>2024-01-02T10:15:30Z</published>
+            <updated>2024-01-02T11:00:00Z</updated>
+          </entry>
+          <entry>
+            <id>tag:example.com,2024:second</id>
+            <title>Second Atom Article</title>
+            <link href="https://example.com/articles/2" />
+            <link rel="self" href="https://example.com/feed/entries/2" />
+            <summary>Only summary body</summary>
+          </entry>
+        </feed>
+        """
+    }
+
+    private func parseDocument(_ xml: String) throws -> FeedXMLDocument {
+        try FeedParserService.parse(Data(xml.utf8))
+    }
+}

--- a/RSSReaderTests/Feeds/FeedDateParsingServiceTests.swift
+++ b/RSSReaderTests/Feeds/FeedDateParsingServiceTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Feeds / Date Parsing")
+struct FeedDateParsingServiceTests {
+    @Test
+    func parsesISO8601DatesWithAndWithoutFractionalSeconds() {
+        assertParsedDate(
+            "2024-01-02T10:15:30.123Z",
+            equals: makeUTCDate(
+                year: 2024,
+                month: 1,
+                day: 2,
+                hour: 10,
+                minute: 15,
+                second: 30,
+                nanosecond: 123_000_000
+            )
+        )
+        assertParsedDate(
+            "2024-01-02T10:15:30Z",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15, second: 30)
+        )
+    }
+
+    @Test
+    func parsesRSSAndRFC822DatesWithOneAndTwoDigitDays() {
+        assertParsedDate(
+            "Tue, 2 Jan 2024 10:15:30 +0000",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15, second: 30)
+        )
+        assertParsedDate(
+            "Tue, 02 Jan 2024 10:15:30 +0000",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15, second: 30)
+        )
+        assertParsedDate(
+            "Tue, 2 Jan 2024 10:15 +0000",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15)
+        )
+        assertParsedDate(
+            "Tue, 02 Jan 2024 10:15 +0000",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15)
+        )
+    }
+
+    @Test
+    func appliesTimezoneOffsetsToParsedDates() {
+        assertParsedDate(
+            "Tue, 02 Jan 2024 13:15:30 +0300",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15, second: 30)
+        )
+        assertParsedDate(
+            "Tue, 02 Jan 2024 05:45:30 -0430",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15, second: 30)
+        )
+        assertParsedDate(
+            "2024-01-02T13:15:30+03:00",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15, second: 30)
+        )
+    }
+
+    @Test
+    func parsesFallbackFormatsWithoutWeekdayOrISOSeparators() {
+        assertParsedDate(
+            "2 Jan 2024 10:15:30 +0000",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15, second: 30)
+        )
+        assertParsedDate(
+            "02 Jan 2024 10:15 +0000",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15)
+        )
+        assertParsedDate(
+            "Tue Jan 2 10:15:30 2024",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15, second: 30)
+        )
+        assertParsedDate(
+            "2024-01-02 13:15:30 +0300",
+            equals: makeUTCDate(year: 2024, month: 1, day: 2, hour: 10, minute: 15, second: 30)
+        )
+        assertParsedDate(
+            "2024-01-02T13:15:30.123+0300",
+            equals: makeUTCDate(
+                year: 2024,
+                month: 1,
+                day: 2,
+                hour: 10,
+                minute: 15,
+                second: 30,
+                nanosecond: 123_000_000
+            )
+        )
+    }
+
+    @Test
+    func returnsNilForEmptyWhitespaceAndInvalidStrings() {
+        #expect(FeedDateParsingService.parse(nil) == nil)
+        #expect(FeedDateParsingService.parse("") == nil)
+        #expect(FeedDateParsingService.parse("   \n\t  ") == nil)
+        #expect(FeedDateParsingService.parse("not a date") == nil)
+        #expect(FeedDateParsingService.parse("2024-13-99T99:99:99Z") == nil)
+    }
+
+    private func assertParsedDate(_ value: String, equals expectedDate: Date) {
+        let parsedDate = FeedDateParsingService.parse(value)
+        #expect(parsedDate != nil)
+        #expect(abs((parsedDate ?? .distantPast).timeIntervalSince(expectedDate)) < 0.001)
+    }
+
+    private func makeUTCDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int,
+        second: Int = 0,
+        nanosecond: Int = 0
+    ) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        components.second = second
+        components.nanosecond = nanosecond
+
+        return components.date ?? Date(timeIntervalSince1970: -1)
+    }
+}

--- a/RSSReaderTests/Feeds/FeedEntryFilteringServiceTests.swift
+++ b/RSSReaderTests/Feeds/FeedEntryFilteringServiceTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Feeds / Entry Filtering")
+struct FeedEntryFilteringServiceTests {
+    @Test
+    func rejectionReasonsCoverMissingExternalIDReadablePayloadAndUsefulReference() {
+        let entry = ParsedFeedEntryDTO(
+            guid: nil,
+            url: "not a url",
+            canonicalURL: nil,
+            title: "   ",
+            summary: nil,
+            contentHTML: nil,
+            contentText: nil
+        )
+
+        let reasons = FeedEntryFilteringService.rejectionReasons(for: entry)
+
+        #expect(reasons == [
+            FeedEntryRejectionReason.missingExternalID,
+            .missingReadablePayload,
+            .missingUsefulReference
+        ])
+        #expect(FeedEntryFilteringService.isValid(entry) == false)
+    }
+
+    @Test
+    func filteringKeepsValidEntriesInOriginalOrderAndRecordsRejectedEntries() throws {
+        let firstValidEntry = makeEntry(
+            externalID: "valid-1",
+            guid: "guid-1",
+            title: "First valid entry"
+        )
+        let rejectedEntry = ParsedFeedEntryDTO(
+            externalID: "rejected-1",
+            title: "Rejected entry without useful reference"
+        )
+        let secondValidEntry = makeEntry(
+            externalID: "valid-2",
+            canonicalURL: "https://example.com/articles/2",
+            summary: "Second summary"
+        )
+
+        let result = FeedEntryFilteringService.filterEntries([
+            firstValidEntry,
+            rejectedEntry,
+            secondValidEntry
+        ])
+
+        #expect(result.validEntries.map(\.externalID) == ["valid-1", "valid-2"])
+        #expect(result.rejectedEntries.count == 1)
+
+        let rejectedDiagnostic = try #require(result.rejectedEntries.first)
+        #expect(rejectedDiagnostic.entry.externalID == "rejected-1")
+        #expect(rejectedDiagnostic.entry.title == "Rejected entry without useful reference")
+        #expect(rejectedDiagnostic.reasons == [FeedEntryRejectionReason.missingUsefulReference])
+    }
+
+    @Test
+    func filterEntriesFromFeedReturnsRejectedDiagnosticsWithoutChangingMetadata() throws {
+        let feed = ParsedFeedDTO(
+            kind: .rss,
+            metadata: ParsedFeedMetadataDTO(
+                title: "Example Feed",
+                siteURL: "https://example.com/"
+            ),
+            entries: [
+                makeEntry(
+                    externalID: "valid",
+                    url: "https://example.com/articles/valid",
+                    contentText: "Readable content"
+                ),
+                ParsedFeedEntryDTO(
+                    externalID: nil,
+                    guid: nil,
+                    url: nil,
+                    canonicalURL: nil,
+                    title: nil,
+                    summary: nil,
+                    contentHTML: nil,
+                    contentText: nil
+                )
+            ]
+        )
+
+        let result = FeedEntryFilteringService.filterEntries(from: feed)
+        let filteredFeed = FeedEntryFilteringService.filterValidEntries(from: feed)
+
+        #expect(result.validEntries.map(\.externalID) == ["valid"])
+        #expect(filteredFeed.kind == .rss)
+        #expect(filteredFeed.metadata.title == "Example Feed")
+        #expect(filteredFeed.metadata.siteURL == "https://example.com/")
+        #expect(filteredFeed.entries.map(\.externalID) == ["valid"])
+
+        let rejectedDiagnostic = try #require(result.rejectedEntries.first)
+        #expect(rejectedDiagnostic.entry.externalID == nil)
+        #expect(rejectedDiagnostic.reasons == [
+            FeedEntryRejectionReason.missingExternalID,
+            .missingReadablePayload,
+            .missingUsefulReference
+        ])
+    }
+
+    private func makeEntry(
+        externalID: String,
+        guid: String? = nil,
+        url: String? = nil,
+        canonicalURL: String? = nil,
+        title: String? = nil,
+        summary: String? = nil,
+        contentHTML: String? = nil,
+        contentText: String? = nil
+    ) -> ParsedFeedEntryDTO {
+        ParsedFeedEntryDTO(
+            externalID: externalID,
+            guid: guid,
+            url: url,
+            canonicalURL: canonicalURL,
+            title: title,
+            summary: summary,
+            contentHTML: contentHTML,
+            contentText: contentText
+        )
+    }
+}

--- a/RSSReaderTests/Feeds/FeedKindDetectionTests.swift
+++ b/RSSReaderTests/Feeds/FeedKindDetectionTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Feeds / Kind Detection")
+struct FeedKindDetectionTests {
+    @Test
+    func detectsRSSFeedFromRootElementName() throws {
+        let document = try FeedParserService.parse(makeData("""
+        <rss version="2.0">
+          <channel />
+        </rss>
+        """))
+
+        #expect(FeedParserService.detectFeedKind(in: document) == .rss)
+        #expect(document.detectedFeedKind == .rss)
+    }
+
+    @Test
+    func detectsAtomFeedFromRootNameAndNamespace() throws {
+        let document = try FeedParserService.parse(makeData("""
+        <feed xmlns="http://www.w3.org/2005/atom">
+          <title>Example Atom Feed</title>
+        </feed>
+        """))
+
+        #expect(FeedParserService.detectFeedKind(in: document) == .atom)
+        #expect(document.detectedFeedKind == .atom)
+    }
+
+    @Test
+    func detectsNamespaceQualifiedFeeds() throws {
+        let qualifiedRSSDocument = try FeedParserService.parse(makeData("""
+        <rss:rss xmlns:rss="https://www.rssboard.org/rss-specification" version="2.0">
+          <rss:channel />
+        </rss:rss>
+        """))
+        let qualifiedAtomDocument = try FeedParserService.parse(makeData("""
+        <atom:feed xmlns:atom="http://www.w3.org/2005/atom">
+          <atom:title>Example Atom Feed</atom:title>
+        </atom:feed>
+        """))
+
+        #expect(FeedParserService.detectFeedKind(in: qualifiedRSSDocument) == .rss)
+        #expect(FeedParserService.detectFeedKind(in: qualifiedAtomDocument) == .atom)
+    }
+
+    @Test
+    func returnsUnknownForUnsupportedRootElements() throws {
+        let document = try FeedParserService.parse(makeData("""
+        <html>
+          <body>Not a feed</body>
+        </html>
+        """))
+
+        #expect(FeedParserService.detectFeedKind(in: document) == .unknown)
+        #expect(document.detectedFeedKind == .unknown)
+    }
+
+    @Test
+    func parseFeedThrowsUnsupportedFeedKindForUnknownDocuments() throws {
+        let document = try FeedParserService.parse(makeData("""
+        <opml version="2.0">
+          <body />
+        </opml>
+        """))
+
+        do {
+            _ = try FeedParserService.parseFeed(document)
+            Issue.record("Expected unknown feed kind to throw")
+        } catch FeedParserError.unsupportedFeedKind(let kind) {
+            #expect(kind == .unknown)
+        } catch {
+            Issue.record("Expected unsupported feed kind error, got \(error)")
+        }
+    }
+
+    private func makeData(_ xml: String) -> Data {
+        Data(xml.utf8)
+    }
+}

--- a/RSSReaderTests/Feeds/FeedRSSParserTests.swift
+++ b/RSSReaderTests/Feeds/FeedRSSParserTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Feeds / RSS Parser")
+struct FeedRSSParserTests {
+    @Test
+    func parsesRSSChannelMetadataAndItemPayloadsFromFixture() throws {
+        let parsedFeed = try FeedParserService.parseRSS(parseDocument(rssFixture))
+
+        #expect(parsedFeed.kind == .rss)
+        #expect(parsedFeed.metadata.title == "Example RSS Feed")
+        #expect(parsedFeed.metadata.subtitle == "Readable feed description")
+        #expect(parsedFeed.metadata.siteURL == "https://example.com/")
+        #expect(parsedFeed.metadata.iconURL == "https://example.com/rss-icon.png")
+        #expect(parsedFeed.metadata.language == "en")
+
+        #expect(parsedFeed.entries.count == 2)
+
+        let firstEntry = try #require(parsedFeed.entries.first)
+        #expect(firstEntry.guid == "article-1")
+        #expect(firstEntry.url == "https://example.com/articles/1")
+        #expect(firstEntry.canonicalURL == "https://example.com/articles/1#comments")
+        #expect(firstEntry.title == "First Article")
+        #expect(firstEntry.summary == "Short first summary")
+        #expect(firstEntry.contentHTML == "<p>Full first article body</p>")
+        #expect(firstEntry.contentText == "Short first summary")
+        #expect(firstEntry.author == "Author One")
+        #expect(firstEntry.publishedAtRaw == "Tue, 02 Jan 2024 10:15:30 +0000")
+        #expect(firstEntry.updatedAtRaw == "Tue, 02 Jan 2024 11:00:00 +0000")
+        #expect(firstEntry.imageURL == "https://example.com/images/first.jpg")
+
+        let secondEntry = try #require(parsedFeed.entries.dropFirst().first)
+        #expect(secondEntry.guid == "article-2")
+        #expect(secondEntry.title == "Second Article")
+        #expect(secondEntry.contentHTML == "Fallback encoded body")
+        #expect(secondEntry.author == "Fallback Creator")
+        #expect(secondEntry.imageURL == nil)
+    }
+
+    @Test
+    func missingChannelThrowsMissingRSSElementDiagnostic() throws {
+        let document = try parseDocument("""
+        <rss version="2.0">
+          <item>
+            <title>Orphan Item</title>
+          </item>
+        </rss>
+        """)
+
+        do {
+            _ = try FeedParserService.parseRSS(document)
+            Issue.record("Expected missing channel to throw")
+        } catch FeedParserError.missingRSSElement(let elementName) {
+            #expect(elementName == "channel")
+        } catch {
+            Issue.record("Expected missing RSS element error, got \(error)")
+        }
+    }
+
+    private var rssFixture: String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss
+            xmlns:content="http://purl.org/rss/1.0/modules/content/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            version="2.0">
+          <channel>
+            <title>Example RSS Feed</title>
+            <link>https://example.com/</link>
+            <description>Readable feed description</description>
+            <language>en</language>
+            <image>
+              <url>https://example.com/rss-icon.png</url>
+            </image>
+            <item>
+              <guid isPermaLink="false">article-1</guid>
+              <link>https://example.com/articles/1</link>
+              <comments>https://example.com/articles/1#comments</comments>
+              <title>First Article</title>
+              <description>Short first summary</description>
+              <content:encoded><![CDATA[<p>Full first article body</p>]]></content:encoded>
+              <dc:creator>Author One</dc:creator>
+              <pubDate>Tue, 02 Jan 2024 10:15:30 +0000</pubDate>
+              <dc:date>Tue, 02 Jan 2024 11:00:00 +0000</dc:date>
+              <enclosure url=" https://example.com/images/first.jpg " type="image/jpeg" />
+            </item>
+            <item>
+              <guid>article-2</guid>
+              <title>Second Article</title>
+              <encoded>Fallback encoded body</encoded>
+              <creator>Fallback Creator</creator>
+            </item>
+          </channel>
+        </rss>
+        """
+    }
+
+    private func parseDocument(_ xml: String) throws -> FeedXMLDocument {
+        try FeedParserService.parse(Data(xml.utf8))
+    }
+}

--- a/RSSReaderTests/Feeds/FeedXMLDocumentBuilderTests.swift
+++ b/RSSReaderTests/Feeds/FeedXMLDocumentBuilderTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Feeds / XML Document Builder")
+struct FeedXMLDocumentBuilderTests {
+    @Test
+    func emptyDocumentThrowsEmptyDocumentError() {
+        assertEmptyDocumentError(for: Data())
+        assertEmptyDocumentError(for: makeData("   \n\t  "))
+    }
+
+    @Test
+    func malformedXMLReportsLineColumnAndParserMessage() {
+        let xml = """
+        <rss>
+          <channel>
+        </rss>
+        """
+
+        do {
+            _ = try FeedParserService.parse(makeData(xml))
+            Issue.record("Expected malformed XML to throw")
+        } catch FeedParserError.malformedXML(let line, let column, let message) {
+            #expect(line > 0)
+            #expect(column > 0)
+            #expect(message.isEmpty == false)
+        } catch {
+            Issue.record("Expected malformed XML error, got \(error)")
+        }
+    }
+
+    @Test
+    func buildsElementTreeWithCDATAAttributesNamespacesAndQualifiedNames() throws {
+        let document = try FeedParserService.parse(makeData(xmlWithNamespacesAndCDATA))
+        let root = document.rootElement
+
+        #expect(root.name == "rss")
+        #expect(root.attributes["version"] == "2.0")
+
+        let channel = try #require(root.firstChild(named: "channel"))
+        #expect(channel.attributes["data-source"] == "fixture")
+        #expect(channel.firstChildText(named: "title") == "Example <Feed>")
+        #expect(channel.nestedChildText(["image", "url"]) == "https://example.com/icon.png")
+
+        let item = try #require(channel.firstChild(named: "item"))
+        #expect(item.attributes["id"] == "article-1")
+
+        let creator = try #require(item.firstChild(named: "creator"))
+        #expect(creator.qualifiedName == "dc:creator")
+        #expect(creator.namespaceURI == "http://purl.org/dc/elements/1.1/")
+        #expect(creator.normalizedText == "Author Name")
+
+        let encodedContent = try #require(item.firstChild(named: "encoded"))
+        #expect(encodedContent.qualifiedName == "content:encoded")
+        #expect(encodedContent.namespaceURI == "http://purl.org/rss/1.0/modules/content/")
+        #expect(encodedContent.normalizedText == "<p>HTML body</p>")
+    }
+
+    @Test
+    func childLookupReturnsFirstMatchingChildAndAllMatchingChildren() throws {
+        let document = try FeedParserService.parse(makeData(xmlWithNamespacesAndCDATA))
+        let channel = try #require(document.rootElement.firstChild(named: "channel"))
+
+        #expect(channel.firstChild(named: "item")?.attributes["id"] == "article-1")
+        #expect(channel.children(named: "item").map(\.attributes["id"]) == ["article-1", "article-2"])
+        #expect(channel.firstChildText(named: "missing") == nil)
+        #expect(channel.nestedChildText(["image", "missing"]) == nil)
+    }
+
+    private var xmlWithNamespacesAndCDATA: String {
+        """
+        <rss
+            xmlns:content="http://purl.org/rss/1.0/modules/content/"
+            xmlns:dc="http://purl.org/dc/elements/1.1/"
+            version="2.0">
+          <channel data-source="fixture">
+            <title><![CDATA[Example <Feed>]]></title>
+            <image>
+              <url> https://example.com/icon.png </url>
+            </image>
+            <item id="article-1">
+              <dc:creator>Author Name</dc:creator>
+              <content:encoded><![CDATA[<p>HTML body</p>]]></content:encoded>
+            </item>
+            <item id="article-2">
+              <title>Second Article</title>
+            </item>
+          </channel>
+        </rss>
+        """
+    }
+
+    private func makeData(_ xml: String) -> Data {
+        Data(xml.utf8)
+    }
+
+    private func assertEmptyDocumentError(for data: Data) {
+        do {
+            _ = try FeedParserService.parse(data)
+            Issue.record("Expected empty document to throw")
+        } catch FeedParserError.emptyDocument {
+            return
+        } catch {
+            Issue.record("Expected empty document error, got \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## Кратко
Задача Feed Input And Parsing Tests выполнена

Реализовано:
- [x] `Feed Date Parsing Matrix Tests`: добавить focused unit tests для `FeedDateParsingService`: ISO8601 с fractional seconds и без них, RSS/RFC822 варианты с одно- и двузначным днём, timezone offsets, fallback formats, пустые и невалидные строки;
- [x] `Feed XML Document Builder Tests`: покрыть `FeedXMLDocumentBuilder` / `FeedXMLDocument` контракт: empty document, malformed XML diagnostics с line/column, CDATA, attributes, namespace / qualified names и поиск child/nested text;
- [x] `Feed Kind Detection Tests`: добавить unit tests для `FeedKindDetection`: RSS, Atom, unknown root, namespace-qualified feeds и unsupported feed kind diagnostics;
- [x] `RSS Parser Fixture Tests`: покрыть `FeedRSSParser` fixtures для channel metadata, `item` payloads, `content:encoded`, `dc:creator`, `dc:date`, enclosure image URL и missing `channel` diagnostics;
- [x] `Atom Parser Fixture Tests`: покрыть `FeedAtomParser` fixtures для feed metadata, `entry` payloads, `alternate` / `self` / `enclosure` links, feed-level author fallback, `content` vs `summary` и missing `feed` diagnostics;
- [x] `Feed Entry Filtering Diagnostics Tests`: добавить unit tests для `FeedEntryFilteringService`: rejection reasons `missingExternalID`, `missingReadablePayload`, `missingUsefulReference`, сохранение порядка valid entries и diagnostic payload для rejected entries.

## Закрывает
Closes #162 
Closes #163 
Closes #164 
Closes #165 
Closes #166 
Closes #167 
Closes #161 