### PR TITLE
Article Identity And Query Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@
 #### Article Identity And Query Tests
 - [x] `Article Identity Contract Tests`: покрыть `ArticleIdentityService` напрямую: приоритет `guid` → `canonicalURL` → `articleURL` → fallback hash, URL normalization, whitespace/title normalization, date normalization и стабильность external ID при эквивалентном input;
 - [x] `Deduplication Merge Contract Tests`: добавить unit tests для `DeduplicationService`: dedup keys по `externalID` / `guid` / `canonicalURL` / `url` / `title+publishedAt`, сохранение порядка, entries без key, merge предпочтения для title, summary/content, author, URLs, image URL и published/updated dates;
-- [ ] `Article Repository Contract Tests`: покрыть `SwiftDataArticleRepository` напрямую: `upsert` create/update без дубликатов, `refreshFeedProjection`, `reconcileArticles` archive/reactivate behavior, inbox/feed sorting и delete batch semantics;
+- [x] `Article Repository Contract Tests`: покрыть `SwiftDataArticleRepository` напрямую: `upsert` create/update без дубликатов, `refreshFeedProjection`, `reconcileArticles` archive/reactivate behavior, inbox/feed sorting и delete batch semantics;
 - [ ] `Article Query Service Contract Tests`: добавить tests для `DefaultArticleQueryService`: `all` / `unread` / `starred` / `hidden` фильтры, folder filtering, state overlay из `ArticleStateRepository`, `ReaderArticleDTO` для existing/missing article и скрытые статьи в list vs reader contract;
 - [ ] `Feed Deletion Cascade Tests`: покрыть `FeedDeletionService`: удаление feed вместе с `Article`, `ArticleState` и `FeedFetchLog`, отсутствие затрагивания соседних feeds и корректное сохранение `ModelContext`.
 

--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@
 - [x] `Article Identity Contract Tests`: покрыть `ArticleIdentityService` напрямую: приоритет `guid` → `canonicalURL` → `articleURL` → fallback hash, URL normalization, whitespace/title normalization, date normalization и стабильность external ID при эквивалентном input;
 - [x] `Deduplication Merge Contract Tests`: добавить unit tests для `DeduplicationService`: dedup keys по `externalID` / `guid` / `canonicalURL` / `url` / `title+publishedAt`, сохранение порядка, entries без key, merge предпочтения для title, summary/content, author, URLs, image URL и published/updated dates;
 - [x] `Article Repository Contract Tests`: покрыть `SwiftDataArticleRepository` напрямую: `upsert` create/update без дубликатов, `refreshFeedProjection`, `reconcileArticles` archive/reactivate behavior, inbox/feed sorting и delete batch semantics;
-- [ ] `Article Query Service Contract Tests`: добавить tests для `DefaultArticleQueryService`: `all` / `unread` / `starred` / `hidden` фильтры, folder filtering, state overlay из `ArticleStateRepository`, `ReaderArticleDTO` для existing/missing article и скрытые статьи в list vs reader contract;
+- [x] `Article Query Service Contract Tests`: добавить tests для `DefaultArticleQueryService`: `all` / `unread` / `starred` / `hidden` фильтры, folder filtering, state overlay из `ArticleStateRepository`, `ReaderArticleDTO` для existing/missing article и скрытые статьи в list vs reader contract;
 - [ ] `Feed Deletion Cascade Tests`: покрыть `FeedDeletionService`: удаление feed вместе с `Article`, `ArticleState` и `FeedFetchLog`, отсутствие затрагивания соседних feeds и корректное сохранение `ModelContext`.
 
 #### App Flow Regression Tests

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@
 - [x] `Deduplication Merge Contract Tests`: добавить unit tests для `DeduplicationService`: dedup keys по `externalID` / `guid` / `canonicalURL` / `url` / `title+publishedAt`, сохранение порядка, entries без key, merge предпочтения для title, summary/content, author, URLs, image URL и published/updated dates;
 - [x] `Article Repository Contract Tests`: покрыть `SwiftDataArticleRepository` напрямую: `upsert` create/update без дубликатов, `refreshFeedProjection`, `reconcileArticles` archive/reactivate behavior, inbox/feed sorting и delete batch semantics;
 - [x] `Article Query Service Contract Tests`: добавить tests для `DefaultArticleQueryService`: `all` / `unread` / `starred` / `hidden` фильтры, folder filtering, state overlay из `ArticleStateRepository`, `ReaderArticleDTO` для existing/missing article и скрытые статьи в list vs reader contract;
-- [ ] `Feed Deletion Cascade Tests`: покрыть `FeedDeletionService`: удаление feed вместе с `Article`, `ArticleState` и `FeedFetchLog`, отсутствие затрагивания соседних feeds и корректное сохранение `ModelContext`.
+- [x] `Feed Deletion Cascade Tests`: покрыть `FeedDeletionService`: удаление feed вместе с `Article`, `ArticleState` и `FeedFetchLog`, отсутствие затрагивания соседних feeds и корректное сохранение `ModelContext`.
 
 #### App Flow Regression Tests
 - [ ] `Add Feed End-To-End Service Pipeline Tests`: добавить non-UI integration tests для add-feed flow через `SourceManagementFeedPreviewService` / `DefaultSourceManagementService` / repositories: preview → create feed → initial refresh scheduling boundary, duplicate feed URL / display name и folder placement;

--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@
 - [x] `Feed Entry Filtering Diagnostics Tests`: добавить unit tests для `FeedEntryFilteringService`: rejection reasons `missingExternalID`, `missingReadablePayload`, `missingUsefulReference`, сохранение порядка valid entries и diagnostic payload для rejected entries.
 
 #### Article Identity And Query Tests
-- [ ] `Article Identity Contract Tests`: покрыть `ArticleIdentityService` напрямую: приоритет `guid` → `canonicalURL` → `articleURL` → fallback hash, URL normalization, whitespace/title normalization, date normalization и стабильность external ID при эквивалентном input;
+- [x] `Article Identity Contract Tests`: покрыть `ArticleIdentityService` напрямую: приоритет `guid` → `canonicalURL` → `articleURL` → fallback hash, URL normalization, whitespace/title normalization, date normalization и стабильность external ID при эквивалентном input;
 - [ ] `Deduplication Merge Contract Tests`: добавить unit tests для `DeduplicationService`: dedup keys по `externalID` / `guid` / `canonicalURL` / `url` / `title+publishedAt`, сохранение порядка, entries без key, merge предпочтения для title, summary/content, author, URLs, image URL и published/updated dates;
 - [ ] `Article Repository Contract Tests`: покрыть `SwiftDataArticleRepository` напрямую: `upsert` create/update без дубликатов, `refreshFeedProjection`, `reconcileArticles` archive/reactivate behavior, inbox/feed sorting и delete batch semantics;
 - [ ] `Article Query Service Contract Tests`: добавить tests для `DefaultArticleQueryService`: `all` / `unread` / `starred` / `hidden` фильтры, folder filtering, state overlay из `ArticleStateRepository`, `ReaderArticleDTO` для existing/missing article и скрытые статьи в list vs reader contract;

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@
 
 #### Article Identity And Query Tests
 - [x] `Article Identity Contract Tests`: покрыть `ArticleIdentityService` напрямую: приоритет `guid` → `canonicalURL` → `articleURL` → fallback hash, URL normalization, whitespace/title normalization, date normalization и стабильность external ID при эквивалентном input;
-- [ ] `Deduplication Merge Contract Tests`: добавить unit tests для `DeduplicationService`: dedup keys по `externalID` / `guid` / `canonicalURL` / `url` / `title+publishedAt`, сохранение порядка, entries без key, merge предпочтения для title, summary/content, author, URLs, image URL и published/updated dates;
+- [x] `Deduplication Merge Contract Tests`: добавить unit tests для `DeduplicationService`: dedup keys по `externalID` / `guid` / `canonicalURL` / `url` / `title+publishedAt`, сохранение порядка, entries без key, merge предпочтения для title, summary/content, author, URLs, image URL и published/updated dates;
 - [ ] `Article Repository Contract Tests`: покрыть `SwiftDataArticleRepository` напрямую: `upsert` create/update без дубликатов, `refreshFeedProjection`, `reconcileArticles` archive/reactivate behavior, inbox/feed sorting и delete batch semantics;
 - [ ] `Article Query Service Contract Tests`: добавить tests для `DefaultArticleQueryService`: `all` / `unread` / `starred` / `hidden` фильтры, folder filtering, state overlay из `ArticleStateRepository`, `ReaderArticleDTO` для existing/missing article и скрытые статьи в list vs reader contract;
 - [ ] `Feed Deletion Cascade Tests`: покрыть `FeedDeletionService`: удаление feed вместе с `Article`, `ArticleState` и `FeedFetchLog`, отсутствие затрагивания соседних feeds и корректное сохранение `ModelContext`.

--- a/RSSReaderTests/Articles/ArticleIdentityServiceTests.swift
+++ b/RSSReaderTests/Articles/ArticleIdentityServiceTests.swift
@@ -1,0 +1,140 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Articles / Identity Service")
+struct ArticleIdentityServiceTests {
+    @Test
+    func externalIDUsesGuidBeforeCanonicalAndArticleURLs() {
+        let externalID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "HTTPS://Feeds.Example.com:443/rss.xml#fragment",
+                guid: "  GUID-123  ",
+                canonicalURL: "https://example.com/canonical",
+                articleURL: "https://example.com/article",
+                title: "Example Title",
+                publishedAt: makeDate()
+            )
+        )
+
+        #expect(externalID == "guid|https://feeds.example.com/rss.xml|GUID-123")
+    }
+
+    @Test
+    func externalIDUsesCanonicalURLBeforeArticleURLWhenGuidIsMissing() {
+        let externalID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "https://feeds.example.com/rss.xml",
+                guid: "   ",
+                canonicalURL: " HTTPS://Example.COM:443/Articles/One?A=1#comments ",
+                articleURL: "https://example.com/articles/fallback",
+                title: "Example Title"
+            )
+        )
+
+        #expect(externalID == "canonical-url|https://feeds.example.com/rss.xml|https://example.com/articles/one?a=1")
+    }
+
+    @Test
+    func externalIDUsesArticleURLWhenGuidAndCanonicalURLAreMissing() {
+        let externalID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "https://feeds.example.com/rss.xml",
+                guid: nil,
+                canonicalURL: nil,
+                articleURL: " HTTP://Example.COM:80/Articles/Two#read-later ",
+                title: "Example Title"
+            )
+        )
+
+        #expect(externalID == "article-url|https://feeds.example.com/rss.xml|http://example.com/articles/two")
+    }
+
+    @Test
+    func fallbackExternalIDNormalizesFeedURLTitleWhitespaceAndDate() {
+        let firstID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "HTTPS://Feeds.Example.com:443/rss.xml#ignored",
+                title: "  Important \n Article\tTitle  ",
+                publishedAt: makeDate()
+            )
+        )
+        let equivalentID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "https://feeds.example.com/rss.xml",
+                title: "important article title",
+                publishedAt: makeDate()
+            )
+        )
+
+        #expect(firstID == equivalentID)
+        #expect(firstID.hasPrefix("fallback|"))
+        #expect(firstID.dropFirst("fallback|".count).count == 64)
+    }
+
+    @Test
+    func fallbackExternalIDChangesWhenNormalizedDateChanges() {
+        let datedID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "https://feeds.example.com/rss.xml",
+                title: "Example Title",
+                publishedAt: makeDate()
+            )
+        )
+        let differentDateID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "https://feeds.example.com/rss.xml",
+                title: "Example Title",
+                publishedAt: makeDate(hour: 11)
+            )
+        )
+        let missingDateID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "https://feeds.example.com/rss.xml",
+                title: "Example Title",
+                publishedAt: nil
+            )
+        )
+
+        #expect(datedID != differentDateID)
+        #expect(datedID != missingDateID)
+        #expect(differentDateID != missingDateID)
+    }
+
+    @Test
+    func equivalentURLInputsProduceStableExternalIDs() {
+        let firstID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "HTTPS://Feeds.Example.com:443/rss.xml",
+                canonicalURL: "HTTPS://Example.COM:443/Article#comments",
+                articleURL: "https://example.com/ignored",
+                title: "Example Title"
+            )
+        )
+        let equivalentID = ArticleIdentityService.makeExternalID(
+            from: ArticleIdentityInput(
+                feedURL: "https://feeds.example.com/rss.xml",
+                canonicalURL: "https://example.com/article",
+                articleURL: nil,
+                title: "Other title does not affect canonical identity"
+            )
+        )
+
+        #expect(firstID == equivalentID)
+    }
+
+    private func makeDate(hour: Int = 10) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        components.year = 2024
+        components.month = 1
+        components.day = 2
+        components.hour = hour
+        components.minute = 15
+        components.second = 30
+        components.nanosecond = 123_000_000
+
+        return components.date ?? Date(timeIntervalSince1970: 0)
+    }
+}

--- a/RSSReaderTests/Articles/DeduplicationServiceTests.swift
+++ b/RSSReaderTests/Articles/DeduplicationServiceTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Articles / Deduplication Service")
+struct DeduplicationServiceTests {
+    @Test
+    func deduplicatesBySupportedKeysAndKeepsFirstKeyOrder() {
+        let entries = [
+            makeEntry(externalID: "external-1", title: "External first"),
+            makeEntry(guid: "guid-1", title: "Guid first"),
+            makeEntry(canonicalURL: "https://example.com/canonical", title: "Canonical first"),
+            makeEntry(url: "https://example.com/article", title: "Article URL first"),
+            makeEntry(title: "Title Date first", publishedAtRaw: "Tue, 02 Jan 2024 10:00:00 +0000"),
+            makeEntry(externalID: " external-1 ", title: "External richer duplicate"),
+            makeEntry(guid: " guid-1 ", title: "Guid richer duplicate"),
+            makeEntry(canonicalURL: " https://example.com/canonical ", title: "Canonical richer duplicate"),
+            makeEntry(url: " https://example.com/article ", title: "Article URL richer duplicate"),
+            makeEntry(title: " Title Date first ", summary: "Title-date duplicate", publishedAtRaw: " Tue, 02 Jan 2024 10:00:00 +0000 "),
+            makeEntry(title: "No key entry")
+        ]
+
+        let deduplicatedEntries = DeduplicationService.deduplicate(entries)
+
+        #expect(deduplicatedEntries.map { $0.title } == [
+            "External richer duplicate",
+            "Guid richer duplicate",
+            "Canonical richer duplicate",
+            "Article URL richer duplicate",
+            "Title Date first",
+            "No key entry"
+        ])
+    }
+
+    @Test
+    func entriesWithoutDeduplicationKeyRemainSeparateAndKeepRelativeOrder() {
+        let entries = [
+            makeEntry(title: "No key first"),
+            makeEntry(title: "No key second"),
+            makeEntry(summary: "No key third")
+        ]
+
+        let deduplicatedEntries = DeduplicationService.deduplicate(entries)
+
+        #expect(deduplicatedEntries.map { $0.title } == [
+            "No key first",
+            "No key second",
+            nil
+        ])
+        #expect(deduplicatedEntries.map { $0.summary } == [
+            nil,
+            nil,
+            "No key third"
+        ])
+    }
+
+    @Test
+    func mergePrefersRicherIdentityTextURLMediaAndDatePayloads() throws {
+        let baseEntry = makeEntry(
+            externalID: "duplicate",
+            guid: "g",
+            url: "http://example.com/a?utm=feed#fragment",
+            canonicalURL: "not a canonical url",
+            title: "https://example.com/title",
+            summary: "short",
+            contentHTML: "plain body",
+            contentText: "short text",
+            author: "author@example.com",
+            publishedAtRaw: "Wed, 03 Jan 2024 10:00:00 +0000",
+            updatedAtRaw: "Wed, 03 Jan 2024 10:00:00 +0000",
+            imageURL: "http://example.com/images/thumb.jpg?utm=feed"
+        )
+        let richerDuplicate = makeEntry(
+            externalID: "duplicate",
+            guid: "longer-guid",
+            url: "https://example.com/articles/full",
+            canonicalURL: "https://example.com/a",
+            title: "Readable Article Title",
+            summary: "Longer readable summary\nwith details",
+            contentHTML: "<article><p>Full HTML body</p></article>",
+            contentText: "Longer readable text payload",
+            author: "Readable Author",
+            publishedAtRaw: "Tue, 02 Jan 2024 10:00:00 +0000",
+            updatedAtRaw: "Thu, 04 Jan 2024 10:00:00 +0000",
+            imageURL: "https://example.com/images/hero.jpg"
+        )
+
+        let deduplicatedEntries = DeduplicationService.deduplicate([baseEntry, richerDuplicate])
+        let mergedEntry = try #require(deduplicatedEntries.first)
+
+        #expect(deduplicatedEntries.count == 1)
+        #expect(mergedEntry.externalID == "duplicate")
+        #expect(mergedEntry.guid == "longer-guid")
+        #expect(mergedEntry.url == "https://example.com/articles/full")
+        #expect(mergedEntry.canonicalURL == "https://example.com/a")
+        #expect(mergedEntry.title == "Readable Article Title")
+        #expect(mergedEntry.summary == "Longer readable summary\nwith details")
+        #expect(mergedEntry.contentHTML == "<article><p>Full HTML body</p></article>")
+        #expect(mergedEntry.contentText == "Longer readable text payload")
+        #expect(mergedEntry.author == "Readable Author")
+        #expect(mergedEntry.publishedAtRaw == "Tue, 02 Jan 2024 10:00:00 +0000")
+        #expect(mergedEntry.updatedAtRaw == "Thu, 04 Jan 2024 10:00:00 +0000")
+        #expect(mergedEntry.imageURL == "https://example.com/images/hero.jpg")
+    }
+
+    @Test
+    func deduplicatingFeedPreservesFeedMetadataAndKind() {
+        let feed = ParsedFeedDTO(
+            kind: .atom,
+            metadata: ParsedFeedMetadataDTO(
+                title: "Example Feed",
+                siteURL: "https://example.com/"
+            ),
+            entries: [
+                makeEntry(externalID: "duplicate", title: "First"),
+                makeEntry(externalID: "duplicate", title: "Second richer title")
+            ]
+        )
+
+        let deduplicatedFeed = DeduplicationService.deduplicate(feed)
+
+        #expect(deduplicatedFeed.kind == .atom)
+        #expect(deduplicatedFeed.metadata.title == "Example Feed")
+        #expect(deduplicatedFeed.metadata.siteURL == "https://example.com/")
+        #expect(deduplicatedFeed.entries.map { $0.title } == ["Second richer title"])
+    }
+
+    private func makeEntry(
+        externalID: String? = nil,
+        guid: String? = nil,
+        url: String? = nil,
+        canonicalURL: String? = nil,
+        title: String? = nil,
+        summary: String? = nil,
+        contentHTML: String? = nil,
+        contentText: String? = nil,
+        author: String? = nil,
+        publishedAtRaw: String? = nil,
+        updatedAtRaw: String? = nil,
+        imageURL: String? = nil
+    ) -> ParsedFeedEntryDTO {
+        ParsedFeedEntryDTO(
+            externalID: externalID,
+            guid: guid,
+            url: url,
+            canonicalURL: canonicalURL,
+            title: title,
+            summary: summary,
+            contentHTML: contentHTML,
+            contentText: contentText,
+            author: author,
+            publishedAtRaw: publishedAtRaw,
+            updatedAtRaw: updatedAtRaw,
+            imageURL: imageURL
+        )
+    }
+}

--- a/RSSReaderTests/Feeds/FeedDeletionServiceTests.swift
+++ b/RSSReaderTests/Feeds/FeedDeletionServiceTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import RSSReader
+
+@Suite("Feeds / Feed Deletion Service")
+@MainActor
+struct FeedDeletionServiceTests {
+    @Test
+    func feedDeletionServiceDeletesFeedArticlesStatesAndFetchLogs() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let deletedFeed = try insertFeed(into: harness, url: "https://example.com/delete.xml")
+        let keptFeed = try insertFeed(into: harness, url: "https://example.com/keep.xml")
+
+        _ = try harness.insertArticle(
+            feed: deletedFeed,
+            externalID: "delete-article-1",
+            url: "https://example.com/delete/1",
+            title: "Delete Article One"
+        )
+        _ = try harness.insertArticle(
+            feed: deletedFeed,
+            externalID: "delete-article-2",
+            url: "https://example.com/delete/2",
+            title: "Delete Article Two"
+        )
+        _ = try harness.insertArticle(
+            feed: keptFeed,
+            externalID: "keep-article",
+            url: "https://example.com/keep/1",
+            title: "Keep Article"
+        )
+
+        try insertArticleState(
+            into: harness,
+            feedID: deletedFeed.id,
+            articleExternalID: "delete-article-1"
+        )
+        try insertArticleState(
+            into: harness,
+            feedID: deletedFeed.id,
+            articleExternalID: "delete-article-2"
+        )
+        try insertArticleState(
+            into: harness,
+            feedID: keptFeed.id,
+            articleExternalID: "keep-article"
+        )
+
+        _ = try harness.feedFetchLogRepository.insert(
+            FeedFetchLogEntry(feedID: deletedFeed.id, status: "success")
+        )
+        _ = try harness.feedFetchLogRepository.insert(
+            FeedFetchLogEntry(feedID: deletedFeed.id, status: "failed")
+        )
+        _ = try harness.feedFetchLogRepository.insert(
+            FeedFetchLogEntry(feedID: keptFeed.id, status: "success")
+        )
+
+        try FeedDeletionService.delete(deletedFeed, in: harness.modelContainer.mainContext)
+
+        #expect(try harness.feedRepository.fetchFeed(id: deletedFeed.id) == nil)
+        #expect(try harness.feedRepository.fetchFeed(id: keptFeed.id)?.id == keptFeed.id)
+        #expect(try articleExternalIDs(in: harness, feedID: deletedFeed.id).isEmpty)
+        #expect(try articleExternalIDs(in: harness, feedID: keptFeed.id) == ["keep-article"])
+        #expect(try articleStateExternalIDs(in: harness, feedID: deletedFeed.id).isEmpty)
+        #expect(try articleStateExternalIDs(in: harness, feedID: keptFeed.id) == ["keep-article"])
+        #expect(try harness.feedFetchLogRepository.fetchLogs(feedID: deletedFeed.id, limit: nil).isEmpty)
+        #expect(try harness.feedFetchLogRepository.fetchLogs(feedID: keptFeed.id, limit: nil).map(\.status) == ["success"])
+    }
+
+    @Test
+    func feedDeletionServiceSavesModelContextAfterCascadeDeletion() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try insertFeed(into: harness, url: "https://example.com/save.xml")
+
+        _ = try harness.insertArticle(
+            feed: feed,
+            externalID: "article",
+            url: "https://example.com/article",
+            title: "Article"
+        )
+        try insertArticleState(into: harness, feedID: feed.id, articleExternalID: "article")
+        _ = try harness.feedFetchLogRepository.insert(
+            FeedFetchLogEntry(feedID: feed.id, status: "success")
+        )
+
+        try FeedDeletionService.delete(feed, in: harness.modelContainer.mainContext)
+
+        #expect(harness.modelContainer.mainContext.hasChanges == false)
+        #expect(try harness.feedRepository.fetchFeed(id: feed.id) == nil)
+        #expect(try articleExternalIDs(in: harness, feedID: feed.id).isEmpty)
+        #expect(try articleStateExternalIDs(in: harness, feedID: feed.id).isEmpty)
+        #expect(try harness.feedFetchLogRepository.fetchLogs(feedID: feed.id, limit: nil).isEmpty)
+    }
+
+    private func insertFeed(
+        into harness: TestHarness,
+        url: String
+    ) throws -> Feed {
+        try harness.feedRepository.insert(
+            Feed(
+                url: url,
+                siteURL: "https://example.com/",
+                title: url
+            )
+        )
+    }
+
+    private func insertArticleState(
+        into harness: TestHarness,
+        feedID: UUID,
+        articleExternalID: String
+    ) throws {
+        try harness.articleStateRepository.upsert(
+            feedID: feedID,
+            articleExternalID: articleExternalID,
+            update: ArticleStateUpsert(
+                isRead: true,
+                updatedAt: Date(timeIntervalSince1970: 100)
+            )
+        )
+    }
+
+    private func articleExternalIDs(
+        in harness: TestHarness,
+        feedID: UUID
+    ) throws -> [String] {
+        try harness.articleRepository.fetchArticles(feedID: feedID).map(\.externalID)
+    }
+
+    private func articleStateExternalIDs(
+        in harness: TestHarness,
+        feedID: UUID
+    ) throws -> [String] {
+        let descriptor = FetchDescriptor<ArticleState>(
+            predicate: #Predicate<ArticleState> { state in
+                state.feedID == feedID
+            },
+            sortBy: [
+                SortDescriptor(\ArticleState.articleExternalID, order: .forward)
+            ]
+        )
+        return try harness.modelContainer.mainContext.fetch(descriptor).map(\.articleExternalID)
+    }
+}

--- a/RSSReaderTests/Queries/ArticleQueryServiceTests.swift
+++ b/RSSReaderTests/Queries/ArticleQueryServiceTests.swift
@@ -1,0 +1,247 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import RSSReader
+
+@Suite("Queries / Article Query Service")
+@MainActor
+struct ArticleQueryServiceTests {
+    @Test
+    func articleQueryServiceAppliesListFiltersAndStateOverlay() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try insertFeed(into: harness)
+        let queryService = makeQueryService(harness)
+
+        _ = try insertArticle(
+            into: harness,
+            feed: feed,
+            externalID: "unread",
+            title: "Unread Article",
+            publishedAt: Date(timeIntervalSince1970: 300)
+        )
+        _ = try insertArticle(
+            into: harness,
+            feed: feed,
+            externalID: "read",
+            title: "Read Article",
+            publishedAt: Date(timeIntervalSince1970: 200)
+        )
+        _ = try insertArticle(
+            into: harness,
+            feed: feed,
+            externalID: "starred",
+            title: "Starred Article",
+            publishedAt: Date(timeIntervalSince1970: 100)
+        )
+        _ = try insertArticle(
+            into: harness,
+            feed: feed,
+            externalID: "hidden",
+            title: "Hidden Article",
+            publishedAt: Date(timeIntervalSince1970: 50)
+        )
+
+        try harness.articleStateRepository.upsert(
+            feedID: feed.id,
+            articleExternalID: "read",
+            update: ArticleStateUpsert(isRead: true, updatedAt: Date(timeIntervalSince1970: 10))
+        )
+        try harness.articleStateRepository.upsert(
+            feedID: feed.id,
+            articleExternalID: "starred",
+            update: ArticleStateUpsert(
+                isRead: true,
+                isStarred: true,
+                updatedAt: Date(timeIntervalSince1970: 20)
+            )
+        )
+        try harness.articleStateRepository.upsert(
+            feedID: feed.id,
+            articleExternalID: "hidden",
+            update: ArticleStateUpsert(
+                isHidden: true,
+                updatedAt: Date(timeIntervalSince1970: 30)
+            )
+        )
+
+        let allItems = try queryService.fetchInboxListItems(sortMode: .publishedAtDescending, filter: .all)
+        let unreadItems = try queryService.fetchInboxListItems(sortMode: .publishedAtDescending, filter: .unread)
+        let starredItems = try queryService.fetchInboxListItems(sortMode: .publishedAtDescending, filter: .starred)
+        let hiddenItems = try queryService.fetchInboxListItems(sortMode: .publishedAtDescending, filter: .hidden)
+
+        #expect(allItems.map { $0.articleExternalID } == ["unread", "read", "starred"])
+        #expect(unreadItems.map { $0.articleExternalID } == ["unread"])
+        #expect(starredItems.map { $0.articleExternalID } == ["starred"])
+        #expect(hiddenItems.map { $0.articleExternalID } == ["hidden"])
+
+        let readItem = try #require(allItems.first { $0.articleExternalID == "read" })
+        let starredItem = try #require(allItems.first { $0.articleExternalID == "starred" })
+        let hiddenItem = try #require(hiddenItems.first)
+
+        #expect(readItem.isRead)
+        #expect(readItem.isStarred == false)
+        #expect(starredItem.isRead)
+        #expect(starredItem.isStarred)
+        #expect(hiddenItem.isHidden)
+    }
+
+    @Test
+    func articleQueryServiceFiltersFolderItemsByStoredFeedFolderName() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let newsFeed = try insertFeed(
+            into: harness,
+            url: "https://example.com/news.xml",
+            title: "News",
+            folderName: "News Folder"
+        )
+        let techFeed = try insertFeed(
+            into: harness,
+            url: "https://example.com/tech.xml",
+            title: "Tech",
+            folderName: "Tech Folder"
+        )
+        let queryService = makeQueryService(harness)
+
+        _ = try insertArticle(
+            into: harness,
+            feed: newsFeed,
+            externalID: "news-article",
+            title: "News Article",
+            publishedAt: Date(timeIntervalSince1970: 200)
+        )
+        _ = try insertArticle(
+            into: harness,
+            feed: techFeed,
+            externalID: "tech-article",
+            title: "Tech Article",
+            publishedAt: Date(timeIntervalSince1970: 100)
+        )
+
+        let newsItems = try queryService.fetchFolderListItems(
+            folderName: "News Folder",
+            sortMode: .publishedAtDescending,
+            filter: .all
+        )
+
+        #expect(newsItems.map { $0.articleExternalID } == ["news-article"])
+        #expect(newsItems.first?.feedTitle == "News")
+    }
+
+    @Test
+    func articleQueryServiceReturnsReaderArticleForExistingHiddenArticleAndNilForMissingArticle() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try insertFeed(into: harness)
+        let queryService = makeQueryService(harness)
+        let article = try insertArticle(
+            into: harness,
+            feed: feed,
+            externalID: "hidden-reader",
+            title: "Hidden Reader Article",
+            summary: "Readable summary",
+            contentHTML: "<p>Readable body</p>",
+            contentText: "Readable body",
+            author: "Author",
+            publishedAt: Date(timeIntervalSince1970: 100),
+            updatedAtSource: Date(timeIntervalSince1970: 200),
+            canonicalURL: "https://example.com/canonical",
+            imageURL: "https://example.com/image.jpg"
+        )
+        try harness.articleStateRepository.upsert(
+            feedID: feed.id,
+            articleExternalID: article.externalID,
+            update: ArticleStateUpsert(
+                isRead: true,
+                isStarred: true,
+                isHidden: true,
+                updatedAt: Date(timeIntervalSince1970: 300)
+            )
+        )
+
+        let listItems = try queryService.fetchInboxListItems(sortMode: .publishedAtDescending, filter: .all)
+        let readerArticle = try #require(try queryService.fetchReaderArticle(id: article.id))
+        let missingReaderArticle = try queryService.fetchReaderArticle(id: UUID())
+
+        #expect(listItems.isEmpty)
+        #expect(readerArticle.id == article.id)
+        #expect(readerArticle.articleExternalID == "hidden-reader")
+        #expect(readerArticle.title == "Hidden Reader Article")
+        #expect(readerArticle.summary == "Readable summary")
+        #expect(readerArticle.contentHTML == "<p>Readable body</p>")
+        #expect(readerArticle.contentText == "Readable body")
+        #expect(readerArticle.author == "Author")
+        #expect(readerArticle.articleURL == "https://example.com/hidden-reader")
+        #expect(readerArticle.canonicalURL == "https://example.com/canonical")
+        #expect(readerArticle.imageURL == "https://example.com/image.jpg")
+        #expect(readerArticle.isRead)
+        #expect(readerArticle.isStarred)
+        #expect(readerArticle.isHidden)
+        #expect(missingReaderArticle == nil)
+    }
+
+    private func makeQueryService(_ harness: TestHarness) -> DefaultArticleQueryService {
+        DefaultArticleQueryService(
+            articleRepository: harness.articleRepository,
+            articleStateRepository: harness.articleStateRepository
+        )
+    }
+
+    private func insertFeed(
+        into harness: TestHarness,
+        url: String = "https://example.com/feed.xml",
+        title: String = "Example Feed",
+        folderName: String? = nil
+    ) throws -> Feed {
+        let folder: Folder?
+        if let folderName {
+            folder = try harness.folderRepository.insert(Folder(name: folderName, sortOrder: 0))
+        } else {
+            folder = nil
+        }
+
+        return try harness.feedRepository.insert(
+            Feed(
+                url: url,
+                siteURL: "https://example.com/",
+                title: title,
+                folder: folder
+            )
+        )
+    }
+
+    private func insertArticle(
+        into harness: TestHarness,
+        feed: Feed,
+        externalID: String,
+        title: String,
+        summary: String? = nil,
+        contentHTML: String? = nil,
+        contentText: String? = nil,
+        author: String? = nil,
+        publishedAt: Date? = nil,
+        updatedAtSource: Date? = nil,
+        canonicalURL: String? = nil,
+        imageURL: String? = nil
+    ) throws -> Article {
+        let article = Article(
+            feedID: feed.id,
+            feedTitle: feed.displayTitle,
+            feedSiteURL: feed.siteURL,
+            feedFolderName: feed.folder?.name,
+            externalID: externalID,
+            url: "https://example.com/\(externalID)",
+            canonicalURL: canonicalURL,
+            title: title,
+            summary: summary,
+            contentHTML: contentHTML,
+            contentText: contentText,
+            author: author,
+            publishedAt: publishedAt,
+            updatedAtSource: updatedAtSource,
+            imageURL: imageURL,
+            fetchedAt: publishedAt ?? Date(timeIntervalSince1970: 0)
+        )
+        harness.modelContainer.mainContext.insert(article)
+        try harness.modelContainer.mainContext.save()
+        return article
+    }
+}

--- a/RSSReaderTests/Repositories/ArticleRepositoryTests.swift
+++ b/RSSReaderTests/Repositories/ArticleRepositoryTests.swift
@@ -1,0 +1,259 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Repositories / Article")
+@MainActor
+struct ArticleRepositoryTests {
+    @Test
+    func articleRepositoryUpsertCreatesAndUpdatesWithoutDuplicates() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try insertFeed(into: harness)
+        let initialFetchedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let updatedFetchedAt = Date(timeIntervalSince1970: 1_700_000_600)
+
+        let createdArticle = try harness.articleRepository.upsert(
+            makeEntry(
+                externalID: "article-1",
+                guid: "guid-1",
+                url: "https://example.com/articles/1",
+                title: "Original title",
+                summary: "Original summary",
+                publishedAtRaw: "Tue, 02 Jan 2024 10:00:00 +0000"
+            ),
+            into: feed,
+            fetchedAt: initialFetchedAt
+        )
+        let updatedArticle = try harness.articleRepository.upsert(
+            makeEntry(
+                externalID: "article-1",
+                guid: "guid-1-updated",
+                url: "https://example.com/articles/1-updated",
+                title: "Updated title",
+                summary: "Updated summary",
+                contentHTML: "<p>Updated HTML</p>",
+                author: "Updated Author",
+                publishedAtRaw: "Tue, 02 Jan 2024 09:00:00 +0000",
+                imageURL: "https://example.com/image.jpg"
+            ),
+            into: feed,
+            fetchedAt: updatedFetchedAt
+        )
+
+        let persistedArticles = try harness.articleRepository.fetchArticles(feedID: feed.id)
+        let persistedArticle = try #require(persistedArticles.first)
+
+        #expect(createdArticle?.id == updatedArticle?.id)
+        #expect(persistedArticles.count == 1)
+        #expect(persistedArticle.externalID == "article-1")
+        #expect(persistedArticle.guid == "guid-1-updated")
+        #expect(persistedArticle.url == "https://example.com/articles/1-updated")
+        #expect(persistedArticle.title == "Updated title")
+        #expect(persistedArticle.summary == "Updated summary")
+        #expect(persistedArticle.contentHTML == "<p>Updated HTML</p>")
+        #expect(persistedArticle.author == "Updated Author")
+        #expect(persistedArticle.imageURL == "https://example.com/image.jpg")
+        #expect(persistedArticle.fetchedAt == updatedFetchedAt)
+    }
+
+    @Test
+    func articleRepositoryRefreshFeedProjectionUpdatesStoredFeedFields() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let folder = try harness.folderRepository.insert(Folder(name: "News", sortOrder: 0))
+        let feed = try insertFeed(
+            into: harness,
+            title: "Original Feed",
+            siteURL: "https://old.example.com/",
+            folder: nil
+        )
+        _ = try harness.insertArticle(
+            feed: feed,
+            externalID: "article-1",
+            url: "https://example.com/articles/1",
+            title: "Article"
+        )
+
+        feed.title = "Updated Feed"
+        feed.displayTitleOverride = "Display Feed"
+        feed.siteURL = "https://new.example.com/"
+        feed.folder = folder
+
+        let updatedCount = try harness.articleRepository.refreshFeedProjection(for: feed)
+        let persistedArticle = try #require(
+            try harness.articleRepository.fetchArticle(feedID: feed.id, externalID: "article-1")
+        )
+
+        #expect(updatedCount == 3)
+        #expect(persistedArticle.feedTitle == "Display Feed")
+        #expect(persistedArticle.feedSiteURL == "https://new.example.com/")
+        #expect(persistedArticle.feedFolderName == "News")
+    }
+
+    @Test
+    func articleRepositoryReconcileArchivesMissingArticlesAndReactivatesKeptArticles() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try insertFeed(into: harness)
+        let firstFetchedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let secondFetchedAt = Date(timeIntervalSince1970: 1_700_000_600)
+        let archivedArticle = try harness.insertArticle(
+            feed: feed,
+            externalID: "archived",
+            url: "https://example.com/archived",
+            title: "Archived"
+        )
+        let keptArticle = try harness.insertArticle(
+            feed: feed,
+            externalID: "kept",
+            url: "https://example.com/kept",
+            title: "Kept"
+        )
+
+        let firstReconcileCount = try harness.articleRepository.reconcileArticles(
+            feedID: feed.id,
+            keepingExternalIDs: ["kept"],
+            fetchedAt: firstFetchedAt
+        )
+
+        #expect(firstReconcileCount == 1)
+        #expect(archivedArticle.archivedAt == firstFetchedAt)
+        #expect(keptArticle.archivedAt == nil)
+
+        let secondReconcileCount = try harness.articleRepository.reconcileArticles(
+            feedID: feed.id,
+            keepingExternalIDs: [" archived ", "kept"],
+            fetchedAt: secondFetchedAt
+        )
+
+        #expect(secondReconcileCount == 1)
+        #expect(archivedArticle.archivedAt == nil)
+        #expect(keptArticle.archivedAt == nil)
+    }
+
+    @Test
+    func articleRepositoryFetchesFeedAndInboxUsingPublishedAtSortModes() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let firstFeed = try insertFeed(into: harness, url: "https://example.com/first.xml")
+        let secondFeed = try insertFeed(into: harness, url: "https://example.com/second.xml")
+
+        _ = try harness.articleRepository.upsert(
+            makeEntry(
+                externalID: "old",
+                url: "https://example.com/old",
+                title: "Old",
+                publishedAtRaw: "Tue, 02 Jan 2024 09:00:00 +0000"
+            ),
+            into: firstFeed,
+            fetchedAt: Date(timeIntervalSince1970: 100)
+        )
+        _ = try harness.articleRepository.upsert(
+            makeEntry(
+                externalID: "new",
+                url: "https://example.com/new",
+                title: "New",
+                publishedAtRaw: "Tue, 02 Jan 2024 11:00:00 +0000"
+            ),
+            into: firstFeed,
+            fetchedAt: Date(timeIntervalSince1970: 200)
+        )
+        _ = try harness.articleRepository.upsert(
+            makeEntry(
+                externalID: "other-feed",
+                url: "https://example.com/other",
+                title: "Other Feed",
+                publishedAtRaw: "Tue, 02 Jan 2024 10:00:00 +0000"
+            ),
+            into: secondFeed,
+            fetchedAt: Date(timeIntervalSince1970: 150)
+        )
+
+        let firstFeedDescending = try harness.articleRepository.fetchArticles(
+            feedID: firstFeed.id,
+            sortMode: .publishedAtDescending
+        )
+        let firstFeedAscending = try harness.articleRepository.fetchArticles(
+            feedID: firstFeed.id,
+            sortMode: .publishedAtAscending
+        )
+        let inboxDescending = try harness.articleRepository.fetchInbox(sortMode: .publishedAtDescending)
+
+        #expect(firstFeedDescending.map { $0.externalID } == ["new", "old"])
+        #expect(firstFeedAscending.map { $0.externalID } == ["old", "new"])
+        #expect(inboxDescending.map { $0.externalID } == ["new", "other-feed", "old"])
+    }
+
+    @Test
+    func articleRepositoryDeleteBatchRemovesOnlyRequestedArticles() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try insertFeed(into: harness)
+        let firstArticle = try harness.insertArticle(
+            feed: feed,
+            externalID: "delete-1",
+            url: "https://example.com/delete-1",
+            title: "Delete One"
+        )
+        let secondArticle = try harness.insertArticle(
+            feed: feed,
+            externalID: "delete-2",
+            url: "https://example.com/delete-2",
+            title: "Delete Two"
+        )
+        let keptArticle = try harness.insertArticle(
+            feed: feed,
+            externalID: "keep",
+            url: "https://example.com/keep",
+            title: "Keep"
+        )
+
+        try harness.articleRepository.delete([firstArticle, secondArticle])
+
+        let remainingArticles = try harness.articleRepository.fetchArticles(feedID: feed.id)
+        #expect(remainingArticles.map { $0.externalID } == [keptArticle.externalID])
+    }
+
+    private func insertFeed(
+        into harness: TestHarness,
+        url: String = "https://example.com/feed.xml",
+        title: String = "Example Feed",
+        siteURL: String? = "https://example.com/",
+        folder: Folder? = nil
+    ) throws -> Feed {
+        try harness.feedRepository.insert(
+            Feed(
+                url: url,
+                siteURL: siteURL,
+                title: title,
+                folder: folder
+            )
+        )
+    }
+
+    private func makeEntry(
+        externalID: String,
+        guid: String? = nil,
+        url: String,
+        canonicalURL: String? = nil,
+        title: String,
+        summary: String? = nil,
+        contentHTML: String? = nil,
+        contentText: String? = nil,
+        author: String? = nil,
+        publishedAtRaw: String? = nil,
+        updatedAtRaw: String? = nil,
+        imageURL: String? = nil
+    ) -> ParsedFeedEntryDTO {
+        ParsedFeedEntryDTO(
+            externalID: externalID,
+            guid: guid,
+            url: url,
+            canonicalURL: canonicalURL,
+            title: title,
+            summary: summary,
+            contentHTML: contentHTML,
+            contentText: contentText,
+            author: author,
+            publishedAtRaw: publishedAtRaw,
+            updatedAtRaw: updatedAtRaw,
+            imageURL: imageURL
+        )
+    }
+}


### PR DESCRIPTION
## Кратко
Задача Article Identity And Query Tests выполнена

Реализовано:
- [x] `Article Identity Contract Tests`: покрыть `ArticleIdentityService` напрямую: приоритет `guid` → `canonicalURL` → `articleURL` → fallback hash, URL normalization, whitespace/title normalization, date normalization и стабильность external ID при эквивалентном input;
- [x] `Deduplication Merge Contract Tests`: добавить unit tests для `DeduplicationService`: dedup keys по `externalID` / `guid` / `canonicalURL` / `url` / `title+publishedAt`, сохранение порядка, entries без key, merge предпочтения для title, summary/content, author, URLs, image URL и published/updated dates;
- [x] `Article Repository Contract Tests`: покрыть `SwiftDataArticleRepository` напрямую: `upsert` create/update без дубликатов, `refreshFeedProjection`, `reconcileArticles` archive/reactivate behavior, inbox/feed sorting и delete batch semantics;
- [x] `Article Query Service Contract Tests`: добавить tests для `DefaultArticleQueryService`: `all` / `unread` / `starred` / `hidden` фильтры, folder filtering, state overlay из `ArticleStateRepository`, `ReaderArticleDTO` для existing/missing article и скрытые статьи в list vs reader contract;
- [x] `Feed Deletion Cascade Tests`: покрыть `FeedDeletionService`: удаление feed вместе с `Article`, `ArticleState` и `FeedFetchLog`, отсутствие затрагивания соседних feeds и корректное сохранение `ModelContext`.

## Закрывает
Closes #598 
Closes #599 
Closes #600 
Closes #601 
Closes #602
Closes #596 