### PR TITLE
App Flow Regression Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@
 - [x] `Feed Deletion Cascade Tests`: покрыть `FeedDeletionService`: удаление feed вместе с `Article`, `ArticleState` и `FeedFetchLog`, отсутствие затрагивания соседних feeds и корректное сохранение `ModelContext`.
 
 #### App Flow Regression Tests
-- [ ] `Add Feed End-To-End Service Pipeline Tests`: добавить non-UI integration tests для add-feed flow через `SourceManagementFeedPreviewService` / `DefaultSourceManagementService` / repositories: preview → create feed → initial refresh scheduling boundary, duplicate feed URL / display name и folder placement;
+- [x] `Add Feed End-To-End Service Pipeline Tests`: добавить non-UI integration tests для add-feed flow через `SourceManagementFeedPreviewService` / `DefaultSourceManagementService` / repositories: preview → create feed → initial refresh scheduling boundary, duplicate feed URL / display name и folder placement;
 - [ ] `Refresh Pipeline Diagnostics Tests`: расширить integration tests `FeedRefreshService`: rejected entry diagnostics, parse failure diagnostics, fetch log persistence, not-modified log path и batch result aggregation без сетевых side effects;
 - [ ] `Reader Opening And Safari Routing Tests`: добавить app-level tests для `ArticleOpeningMode` / `ArticleBodyLinkOpeningPolicy` / `ArticleSourceLinkOpeningPolicy`: выбор между app-owned reader и `SFSafariViewController`, body link routing, source article routing и dismissal state;
 - [ ] `Settings Side Effects Regression Tests`: покрыть non-UI side effects `SettingsScreenController`: cache clear actions, archive purge, badge preference apply, background refresh preference update и iCloud sync preference transition без изменения unrelated settings.

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@
 #### App Flow Regression Tests
 - [x] `Add Feed End-To-End Service Pipeline Tests`: добавить non-UI integration tests для add-feed flow через `SourceManagementFeedPreviewService` / `DefaultSourceManagementService` / repositories: preview → create feed → initial refresh scheduling boundary, duplicate feed URL / display name и folder placement;
 - [x] `Refresh Pipeline Diagnostics Tests`: расширить integration tests `FeedRefreshService`: rejected entry diagnostics, parse failure diagnostics, fetch log persistence, not-modified log path и batch result aggregation без сетевых side effects;
-- [ ] `Reader Opening And Safari Routing Tests`: добавить app-level tests для `ArticleOpeningMode` / `ArticleBodyLinkOpeningPolicy` / `ArticleSourceLinkOpeningPolicy`: выбор между app-owned reader и `SFSafariViewController`, body link routing, source article routing и dismissal state;
+- [x] `Reader Opening And Safari Routing Tests`: добавить app-level tests для `ArticleOpeningMode` / `ArticleBodyLinkOpeningPolicy` / `ArticleSourceLinkOpeningPolicy`: выбор между app-owned reader и `SFSafariViewController`, body link routing, source article routing и dismissal state;
 - [ ] `Settings Side Effects Regression Tests`: покрыть non-UI side effects `SettingsScreenController`: cache clear actions, archive purge, badge preference apply, background refresh preference update и iCloud sync preference transition без изменения unrelated settings.
 
 ### Deferred Validation

--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@
 - [x] `Add Feed End-To-End Service Pipeline Tests`: добавить non-UI integration tests для add-feed flow через `SourceManagementFeedPreviewService` / `DefaultSourceManagementService` / repositories: preview → create feed → initial refresh scheduling boundary, duplicate feed URL / display name и folder placement;
 - [x] `Refresh Pipeline Diagnostics Tests`: расширить integration tests `FeedRefreshService`: rejected entry diagnostics, parse failure diagnostics, fetch log persistence, not-modified log path и batch result aggregation без сетевых side effects;
 - [x] `Reader Opening And Safari Routing Tests`: добавить app-level tests для `ArticleOpeningMode` / `ArticleBodyLinkOpeningPolicy` / `ArticleSourceLinkOpeningPolicy`: выбор между app-owned reader и `SFSafariViewController`, body link routing, source article routing и dismissal state;
-- [ ] `Settings Side Effects Regression Tests`: покрыть non-UI side effects `SettingsScreenController`: cache clear actions, archive purge, badge preference apply, background refresh preference update и iCloud sync preference transition без изменения unrelated settings.
+- [x] `Settings Side Effects Regression Tests`: покрыть non-UI side effects `SettingsScreenController`: cache clear actions, archive purge, badge preference apply, background refresh preference update и iCloud sync preference transition без изменения unrelated settings.
 
 ### Deferred Validation
 #### Sync Real-Device Validation Kit

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@
 
 #### App Flow Regression Tests
 - [x] `Add Feed End-To-End Service Pipeline Tests`: добавить non-UI integration tests для add-feed flow через `SourceManagementFeedPreviewService` / `DefaultSourceManagementService` / repositories: preview → create feed → initial refresh scheduling boundary, duplicate feed URL / display name и folder placement;
-- [ ] `Refresh Pipeline Diagnostics Tests`: расширить integration tests `FeedRefreshService`: rejected entry diagnostics, parse failure diagnostics, fetch log persistence, not-modified log path и batch result aggregation без сетевых side effects;
+- [x] `Refresh Pipeline Diagnostics Tests`: расширить integration tests `FeedRefreshService`: rejected entry diagnostics, parse failure diagnostics, fetch log persistence, not-modified log path и batch result aggregation без сетевых side effects;
 - [ ] `Reader Opening And Safari Routing Tests`: добавить app-level tests для `ArticleOpeningMode` / `ArticleBodyLinkOpeningPolicy` / `ArticleSourceLinkOpeningPolicy`: выбор между app-owned reader и `SFSafariViewController`, body link routing, source article routing и dismissal state;
 - [ ] `Settings Side Effects Regression Tests`: покрыть non-UI side effects `SettingsScreenController`: cache clear actions, archive purge, badge preference apply, background refresh preference update и iCloud sync preference transition без изменения unrelated settings.
 

--- a/RSSReaderTests/Feeds/FeedRefreshServiceDiagnosticsTests.swift
+++ b/RSSReaderTests/Feeds/FeedRefreshServiceDiagnosticsTests.swift
@@ -1,0 +1,239 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Feeds / Refresh Service / Diagnostics")
+@MainActor
+struct FeedRefreshServiceDiagnosticsTests {
+    @Test
+    func refreshFetchedPayloadPersistsRejectedEntryDiagnosticsAndFetchLogMessage() async throws {
+        let feedURL = "https://example.com/diagnostics.xml"
+        let harness = try TestHarness.make(
+            httpClient: ScriptedHTTPClient(
+                responsesByURL: [
+                    feedURL: .response(
+                        statusCode: 200,
+                        headers: [
+                            "Content-Type": "application/rss+xml; charset=utf-8"
+                        ],
+                        body: makeRSSFeedWithValidAndRejectedEntries(
+                            channelTitle: "Diagnostics Feed",
+                            channelLink: "https://example.com/",
+                            validItemTitle: "Valid Diagnostics Article",
+                            validItemLink: "https://example.com/articles/valid",
+                            validItemGUID: "valid-diagnostics-article"
+                        )
+                    )
+                ]
+            )
+        )
+        let feed = try #require(try harness.insertFeeds(urls: [feedURL]).first)
+
+        let result = await harness.service.refresh(feedID: feed.id)
+
+        #expect(result.status == .fetched)
+        #expect(result.processedEntryCount == 2)
+        #expect(result.upsertedEntryCount == 1)
+        #expect(result.rejectedEntryCount == 1)
+        #expect(result.diagnosticsSummary.parserAnomalyCount == 4)
+        #expect(result.diagnosticsSummary.rejectedEntryCount == 1)
+        #expect(result.diagnosticsSummary.hasSoftFailures)
+
+        let articles = try harness.articleRepository.fetchArticles(feedID: feed.id)
+        #expect(articles.map(\.title) == ["Valid Diagnostics Article"])
+
+        let latestLog = try #require(try harness.feedFetchLogRepository.fetchLatestLog(feedID: feed.id))
+        #expect(latestLog.status == "fetched")
+        #expect(latestLog.httpCode == 200)
+        #expect(latestLog.message?.contains("diagnostics(parser_anomalies=4, rejected_entries=1)") == true)
+    }
+
+    @Test
+    func refreshParseFailurePersistsFailureStateAndFetchLogWithoutArticles() async throws {
+        let feedURL = "https://example.com/malformed.xml"
+        let harness = try TestHarness.make(
+            httpClient: ScriptedHTTPClient(
+                responsesByURL: [
+                    feedURL: .response(
+                        statusCode: 200,
+                        headers: [
+                            "Content-Type": "application/rss+xml; charset=utf-8"
+                        ],
+                        body: """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <rss version="2.0">
+                          <channel>
+                            <title>Malformed Feed</title>
+                        """
+                    )
+                ]
+            )
+        )
+        let feed = try #require(try harness.insertFeeds(urls: [feedURL]).first)
+
+        let result = await harness.service.refresh(feedID: feed.id)
+
+        #expect(result.status == .failed)
+        #expect(result.processedEntryCount == 0)
+        #expect(result.upsertedEntryCount == 0)
+        #expect(result.rejectedEntryCount == 0)
+        #expect(result.diagnosticsSummary.parserAnomalyCount == 0)
+        #expect(result.diagnosticsSummary.rejectedEntryCount == 0)
+        #expect(result.errorDescription?.contains("malformedXML") == true)
+
+        let refreshedFeed = try #require(try harness.fetchFeed(id: feed.id))
+        #expect(refreshedFeed.lastFetchedAt != nil)
+        #expect(refreshedFeed.lastSuccessfulFetchAt == nil)
+        #expect(refreshedFeed.lastSyncError?.contains("malformedXML") == true)
+        #expect(try harness.articleRepository.fetchArticles(feedID: feed.id).isEmpty)
+
+        let latestLog = try #require(try harness.feedFetchLogRepository.fetchLatestLog(feedID: feed.id))
+        #expect(latestLog.status == "failed")
+        #expect(latestLog.httpCode == nil)
+        #expect(latestLog.message?.contains("diagnostics(parser_anomalies=0, rejected_entries=0)") == true)
+        #expect(latestLog.message?.contains("malformedXML") == true)
+    }
+
+    @Test
+    func refreshNotModifiedPersistsDiagnosticsLogMessageWithoutPayloadSideEffects() async throws {
+        let feedURL = "https://example.com/not-modified-diagnostics.xml"
+        let oldSuccessAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let harness = try TestHarness.make(
+            httpClient: ScriptedHTTPClient(
+                responsesByURL: [
+                    feedURL: .response(
+                        statusCode: 304,
+                        headers: [
+                            "ETag": "\"etag-not-modified\"",
+                            "Last-Modified": "Wed, 03 Jan 2024 12:00:00 GMT"
+                        ],
+                        body: ""
+                    )
+                ]
+            )
+        )
+        let feed = Feed(
+            url: feedURL,
+            title: "Not Modified Diagnostics",
+            lastSuccessfulFetchAt: oldSuccessAt,
+            lastETag: "\"etag-old\"",
+            lastModifiedHeader: "Tue, 02 Jan 2024 12:00:00 GMT",
+            lastSyncError: "Previous error"
+        )
+        try harness.feedRepository.insert(feed)
+
+        let result = await harness.service.refresh(feedID: feed.id)
+
+        #expect(result.status == .notModified)
+        #expect(result.diagnosticsSummary.parserAnomalyCount == 0)
+        #expect(result.diagnosticsSummary.rejectedEntryCount == 0)
+        #expect(result.errorDescription == nil)
+        #expect(try harness.articleRepository.fetchArticles(feedID: feed.id).isEmpty)
+
+        let refreshedFeed = try #require(try harness.fetchFeed(id: feed.id))
+        #expect(refreshedFeed.lastSuccessfulFetchAt == oldSuccessAt)
+        #expect(refreshedFeed.lastETag == "\"etag-not-modified\"")
+        #expect(refreshedFeed.lastModifiedHeader == "Wed, 03 Jan 2024 12:00:00 GMT")
+        #expect(refreshedFeed.lastSyncError == nil)
+
+        let latestLog = try #require(try harness.feedFetchLogRepository.fetchLatestLog(feedID: feed.id))
+        #expect(latestLog.status == "not_modified")
+        #expect(latestLog.httpCode == 304)
+        #expect(latestLog.message?.contains("Feed not modified") == true)
+        #expect(latestLog.message?.contains("diagnostics(parser_anomalies=0, rejected_entries=0)") == true)
+    }
+
+    @Test
+    func batchRefreshAggregatesDiagnosticsAndUsesOnlyScriptedRequests() async throws {
+        let fetchedURL = "https://example.com/batch-diagnostics-fetched.xml"
+        let notModifiedURL = "https://example.com/batch-diagnostics-not-modified.xml"
+        let failedURL = "https://example.com/batch-diagnostics-failed.xml"
+        let client = ScriptedHTTPClient(
+            responsesByURL: [
+                fetchedURL: .response(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Type": "application/rss+xml; charset=utf-8"
+                    ],
+                    body: makeRSSFeedWithValidAndRejectedEntries(
+                        channelTitle: "Batch Diagnostics Fetched",
+                        channelLink: "https://example.com/batch/",
+                        validItemTitle: "Batch Valid Article",
+                        validItemLink: "https://example.com/batch/articles/valid",
+                        validItemGUID: "batch-valid-article"
+                    )
+                ),
+                notModifiedURL: .response(
+                    statusCode: 304,
+                    headers: [
+                        "ETag": "\"etag-batch-not-modified\""
+                    ],
+                    body: ""
+                ),
+                failedURL: .response(
+                    statusCode: 200,
+                    headers: [
+                        "Content-Type": "application/rss+xml; charset=utf-8"
+                    ],
+                    body: "<rss><channel><title>Broken"
+                )
+            ]
+        )
+        let harness = try TestHarness.make(httpClient: client)
+        let feeds = try harness.insertFeeds(urls: [fetchedURL, notModifiedURL, failedURL])
+
+        let result = await harness.service.refreshFeeds(feeds.map(\.id))
+
+        #expect(result.results.map(\.status) == [.fetched, .notModified, .failed])
+        #expect(result.summary.totalFeedCount == 3)
+        #expect(result.summary.fetchedCount == 1)
+        #expect(result.summary.notModifiedCount == 1)
+        #expect(result.summary.failedCount == 1)
+        #expect(result.summary.cancelledCount == 0)
+        #expect(result.summary.totalProcessedEntryCount == 2)
+        #expect(result.summary.totalUpsertedEntryCount == 1)
+        #expect(result.summary.totalRejectedEntryCount == 1)
+        #expect(result.errors.count == 1)
+        #expect(result.errors.first?.feedID == feeds[2].id)
+        #expect(result.errors.first?.message.contains("malformedXML") == true)
+
+        let fetchedLogs = try harness.feedFetchLogRepository.fetchLogs(feedID: feeds[0].id, limit: nil)
+        let notModifiedLogs = try harness.feedFetchLogRepository.fetchLogs(feedID: feeds[1].id, limit: nil)
+        let failedLogs = try harness.feedFetchLogRepository.fetchLogs(feedID: feeds[2].id, limit: nil)
+        #expect(fetchedLogs.first?.message?.contains("diagnostics(parser_anomalies=4, rejected_entries=1)") == true)
+        #expect(notModifiedLogs.first?.status == "not_modified")
+        #expect(failedLogs.first?.message?.contains("malformedXML") == true)
+
+        let requestedURLs = Set(await client.recordedRequests().map(\.url.absoluteString))
+        #expect(requestedURLs == Set([fetchedURL, notModifiedURL, failedURL]))
+    }
+
+    private func makeRSSFeedWithValidAndRejectedEntries(
+        channelTitle: String,
+        channelLink: String,
+        validItemTitle: String,
+        validItemLink: String,
+        validItemGUID: String
+    ) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>\(channelTitle)</title>
+            <link>\(channelLink)</link>
+            <description>Diagnostics feed</description>
+            <language>en</language>
+            <item>
+              <title>\(validItemTitle)</title>
+              <link>\(validItemLink)</link>
+              <guid isPermaLink="false">\(validItemGUID)</guid>
+              <description>Readable summary</description>
+              <pubDate>Tue, 02 Jan 2024 10:00:00 GMT</pubDate>
+            </item>
+            <item>
+            </item>
+          </channel>
+        </rss>
+        """
+    }
+}

--- a/RSSReaderTests/Settings/SettingsScreenControllerSideEffectsTests.swift
+++ b/RSSReaderTests/Settings/SettingsScreenControllerSideEffectsTests.swift
@@ -1,0 +1,296 @@
+import Foundation
+import Testing
+import UIKit
+@testable import RSSReader
+
+@Suite("Settings Screen / Controller / Side Effects")
+@MainActor
+struct SettingsScreenControllerSideEffectsTests {
+    @Test
+    func settingsScreenControllerClearsArticleImageCacheWithoutChangingSettings() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let settingsService = try #require(harness.dependencies.appSettingsService)
+        let controller = SettingsScreenController()
+        let imageURL = try #require(URL(string: "https://example.com/article-image.png"))
+        let initialSnapshot = try settingsService.fetchSettings()
+
+        ArticleImageMemoryCache.shared.insert(UIImage(), for: imageURL)
+        controller.screenState.applyArticleImageCacheAvailability(true)
+
+        await controller.handleButtonTap(
+            itemID: .clearArticleImageCache,
+            dependencies: harness.dependencies
+        )
+
+        #expect(ArticleImageMemoryCache.shared.hasImages == false)
+        #expect(controller.screenState.hasArticleImageCache == false)
+        #expect(try settingsService.fetchSettings() == initialSnapshot)
+    }
+
+    @Test
+    func settingsScreenControllerClearsSourceIconCacheAndRequestsIconResetWithoutChangingSettings() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let sourceIconCache = SettingsRecordingSourceIconCache(hasCachedDataValue: true)
+        let dependencies = AppDependencies(
+            logger: TestLogger(),
+            httpClient: harness.httpClient,
+            feedFetcher: harness.dependencies.feedFetcher,
+            sourceIconCache: sourceIconCache,
+            modelContainer: harness.modelContainer,
+            unreadAppIconBadgeService: NoOpUnreadAppIconBadgeService()
+        )
+        let settingsService = try #require(dependencies.appSettingsService)
+        let controller = SettingsScreenController()
+        let appState = AppState()
+        let resetIDBeforeClear = appState.sourceIconCacheResetID
+        let initialSnapshot = try settingsService.fetchSettings()
+
+        await controller.refreshSourceIconCacheAvailability(dependencies: dependencies)
+        #expect(controller.screenState.hasSourceIconCache)
+
+        await controller.handleButtonTap(
+            itemID: .clearSourceIconCache,
+            dependencies: dependencies,
+            appState: appState
+        )
+
+        #expect(await sourceIconCache.removeAllCallCount() == 1)
+        #expect(controller.screenState.hasSourceIconCache == false)
+        #expect(appState.sourceIconCacheResetID != resetIDBeforeClear)
+        #expect(try settingsService.fetchSettings() == initialSnapshot)
+    }
+
+    @Test
+    func settingsScreenControllerPurgesArchivedArticlesAndReloadsListsWithoutChangingSettings() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let settingsService = try #require(harness.dependencies.appSettingsService)
+        let feed = try harness.insertFeeds(urls: ["https://example.com/feed.xml"])[0]
+        let archivedArticle = try harness.insertArticle(
+            feed: feed,
+            externalID: "archived",
+            url: "https://example.com/archived",
+            title: "Archived",
+            archivedAt: Date(timeIntervalSince1970: 1)
+        )
+        let starredArchivedArticle = try harness.insertArticle(
+            feed: feed,
+            externalID: "starred-archived",
+            url: "https://example.com/starred-archived",
+            title: "Starred Archived",
+            archivedAt: Date(timeIntervalSince1970: 2)
+        )
+        let currentArticle = try harness.insertArticle(
+            feed: feed,
+            externalID: "current",
+            url: "https://example.com/current",
+            title: "Current"
+        )
+        _ = try harness.articleStateService.toggleStarred(article: starredArchivedArticle)
+        let controller = SettingsScreenController()
+        let appState = AppState()
+        let articleListReloadIDBeforePurge = appState.articleListReloadID
+        let sourcesSidebarReloadIDBeforePurge = appState.sourcesSidebarReloadID
+        let initialSnapshot = try settingsService.fetchSettings()
+
+        controller.refreshArchivedArticlesAvailability(dependencies: harness.dependencies)
+        #expect(controller.screenState.hasArchivedArticles)
+
+        await controller.handleButtonTap(
+            itemID: .purgeArchivedArticles,
+            dependencies: harness.dependencies,
+            appState: appState
+        )
+
+        #expect(try harness.articleRepository.fetchArticle(id: archivedArticle.id) == nil)
+        #expect(try harness.articleRepository.fetchArticle(id: starredArchivedArticle.id) != nil)
+        #expect(try harness.articleRepository.fetchArticle(id: currentArticle.id) != nil)
+        #expect(controller.screenState.hasArchivedArticles == false)
+        #expect(appState.articleListReloadID != articleListReloadIDBeforePurge)
+        #expect(appState.sourcesSidebarReloadID != sourcesSidebarReloadIDBeforePurge)
+        #expect(try settingsService.fetchSettings() == initialSnapshot)
+    }
+
+    @Test
+    func settingsScreenControllerAppliesBadgePreferenceAndRefreshScheduleWithoutChangingUnrelatedSettings() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let badgeService = SettingsRecordingUnreadAppIconBadgeService()
+        let scheduler = SettingsRecordingBackgroundRefreshScheduler()
+        let dependencies = AppDependencies(
+            logger: TestLogger(),
+            httpClient: harness.httpClient,
+            feedFetcher: harness.dependencies.feedFetcher,
+            modelContainer: harness.modelContainer,
+            backgroundRefreshScheduler: scheduler,
+            unreadAppIconBadgeService: badgeService
+        )
+        let settingsService = try #require(dependencies.appSettingsService)
+        let controller = SettingsScreenController()
+        let initialSnapshot = AppSettingsSnapshot(
+            articleOpeningMode: .safariView,
+            refreshIntervalPreference: .manual,
+            useiCloudSync: false,
+            markAsReadOnOpen: false,
+            askBeforeMarkingAllAsRead: true,
+            showUnreadCountBadge: false,
+            unreadArticleSortMode: .publishedAtAscending,
+            articleRetentionPolicy: .oneMonth,
+            articleBodyLinkOpeningPolicy: .externalBrowser,
+            articleSourceLinkOpeningPolicy: .externalBrowser,
+            readerAdjacentNavigationControlsMode: .toolbarControlsOnly,
+            interfaceThemeMode: .dark
+        )
+        _ = try settingsService.saveSettings(initialSnapshot, updatedAt: .distantPast)
+
+        controller.loadSettings(dependencies: dependencies)
+        controller.handleToggleValueChange(
+            itemID: .showUnreadCountBadge,
+            isOn: true,
+            dependencies: dependencies
+        )
+        controller.handlePickerOptionSelection(
+            itemID: .refreshInterval,
+            optionID: RefreshPreference.hourly.rawValue,
+            dependencies: dependencies
+        )
+
+        #expect(controller.applySettingsChanges(dependencies: dependencies))
+        await waitForBadgePreferences([true], in: badgeService)
+        let persistedSnapshot = try settingsService.fetchSettings()
+        let replacedConfiguration = try #require(scheduler.lastReplacedConfiguration)
+
+        #expect(badgeService.appliedPreferences == [true])
+        #expect(replacedConfiguration.settingsSnapshot.refreshIntervalPreference == .hourly)
+        #expect(replacedConfiguration.policy.minimumInterval == TimeInterval(60 * 60))
+        #expect(persistedSnapshot.showUnreadCountBadge)
+        #expect(persistedSnapshot.refreshIntervalPreference == .hourly)
+        #expect(persistedSnapshot.articleOpeningMode == initialSnapshot.articleOpeningMode)
+        #expect(persistedSnapshot.useiCloudSync == initialSnapshot.useiCloudSync)
+        #expect(persistedSnapshot.markAsReadOnOpen == initialSnapshot.markAsReadOnOpen)
+        #expect(persistedSnapshot.articleRetentionPolicy == initialSnapshot.articleRetentionPolicy)
+        #expect(persistedSnapshot.interfaceThemeMode == initialSnapshot.interfaceThemeMode)
+    }
+
+    @Test
+    func settingsScreenControllerPersistsICloudSyncBootPreferenceTransitionWithoutChangingUnrelatedSettings() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let syncBootstrapPreferenceStore = SettingsRecordingSyncBootstrapPreferenceStore()
+        let dependencies = AppDependencies(
+            logger: TestLogger(),
+            httpClient: harness.httpClient,
+            feedFetcher: harness.dependencies.feedFetcher,
+            modelContainer: harness.modelContainer,
+            syncBootstrapPreferenceStore: syncBootstrapPreferenceStore,
+            unreadAppIconBadgeService: NoOpUnreadAppIconBadgeService()
+        )
+        let settingsService = try #require(dependencies.appSettingsService)
+        let controller = SettingsScreenController()
+        let initialSnapshot = AppSettingsSnapshot(
+            articleOpeningMode: .safariView,
+            refreshIntervalPreference: .daily,
+            useiCloudSync: false,
+            markAsReadOnOpen: false,
+            askBeforeMarkingAllAsRead: false,
+            showUnreadCountBadge: true,
+            unreadArticleSortMode: .publishedAtAscending,
+            articleRetentionPolicy: .twoWeeks,
+            articleBodyLinkOpeningPolicy: .externalBrowser,
+            articleSourceLinkOpeningPolicy: .externalBrowser,
+            readerAdjacentNavigationControlsMode: .swipesOnly,
+            interfaceThemeMode: .black
+        )
+        _ = try settingsService.saveSettings(initialSnapshot, updatedAt: .distantPast)
+
+        controller.loadSettings(dependencies: dependencies)
+        controller.handleToggleValueChange(
+            itemID: .useICloudSync,
+            isOn: true,
+            dependencies: dependencies
+        )
+
+        #expect(controller.applySettingsChanges(dependencies: dependencies))
+        let persistedSnapshot = try settingsService.fetchSettings()
+
+        #expect(syncBootstrapPreferenceStore.savedPreferences == [.enabled])
+        #expect(syncBootstrapPreferenceStore.currentBootPreference() == .enabled)
+        #expect(persistedSnapshot.useiCloudSync)
+        #expect(persistedSnapshot.articleOpeningMode == initialSnapshot.articleOpeningMode)
+        #expect(persistedSnapshot.refreshIntervalPreference == initialSnapshot.refreshIntervalPreference)
+        #expect(persistedSnapshot.markAsReadOnOpen == initialSnapshot.markAsReadOnOpen)
+        #expect(persistedSnapshot.askBeforeMarkingAllAsRead == initialSnapshot.askBeforeMarkingAllAsRead)
+        #expect(persistedSnapshot.showUnreadCountBadge == initialSnapshot.showUnreadCountBadge)
+        #expect(persistedSnapshot.articleRetentionPolicy == initialSnapshot.articleRetentionPolicy)
+        #expect(persistedSnapshot.interfaceThemeMode == initialSnapshot.interfaceThemeMode)
+    }
+}
+
+private actor SettingsRecordingSourceIconCache: SourceIconCaching {
+    private var hasCachedDataValue: Bool
+    private var removeAllCount = 0
+
+    init(hasCachedDataValue: Bool = false) {
+        self.hasCachedDataValue = hasCachedDataValue
+    }
+
+    func cachedImageData(for url: URL) async throws -> Data? {
+        nil
+    }
+
+    func storeImageData(_ data: Data, for url: URL) async throws {
+        hasCachedDataValue = true
+    }
+
+    func imageData(for url: URL) async throws -> Data {
+        Data()
+    }
+
+    func hasCachedData() async throws -> Bool {
+        hasCachedDataValue
+    }
+
+    func removeAllCachedData() async throws {
+        removeAllCount += 1
+        hasCachedDataValue = false
+    }
+
+    func removeAllCallCount() -> Int {
+        removeAllCount
+    }
+}
+
+@MainActor
+private final class SettingsRecordingUnreadAppIconBadgeService: UnreadAppIconBadgeServicing {
+    private(set) var appliedPreferences: [Bool] = []
+
+    func refreshBadgeCount() async {}
+
+    func applyBadgePreference(isEnabled: Bool) async {
+        appliedPreferences.append(isEnabled)
+    }
+}
+
+private final class SettingsRecordingSyncBootstrapPreferenceStore: AppSyncBootstrapPreferenceStoring {
+    private var bootPreference: AppSyncBootPreference?
+    private(set) var savedPreferences: [AppSyncBootPreference] = []
+
+    func currentBootPreference() -> AppSyncBootPreference? {
+        bootPreference
+    }
+
+    func saveBootPreference(_ preference: AppSyncBootPreference) {
+        bootPreference = preference
+        savedPreferences.append(preference)
+    }
+}
+
+@MainActor
+private func waitForBadgePreferences(
+    _ expectedPreferences: [Bool],
+    in badgeService: SettingsRecordingUnreadAppIconBadgeService
+) async {
+    for _ in 0..<20 {
+        if badgeService.appliedPreferences == expectedPreferences {
+            return
+        }
+        await Task.yield()
+    }
+}

--- a/RSSReaderTests/Shell/ReaderOpeningAndSafariRoutingTests.swift
+++ b/RSSReaderTests/Shell/ReaderOpeningAndSafariRoutingTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import RSSReader
+
+@Suite("Shell / Reader Opening And Safari Routing")
+@MainActor
+struct ReaderOpeningAndSafariRoutingTests {
+    @Test
+    func readerOpeningModeFeedReaderSelectsAppOwnedReaderWithoutPresentingSafari() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appState = AppState()
+        let article = try insertArticle(
+            into: harness,
+            feedURL: "https://example.com/feed-reader-mode.xml",
+            externalID: "feed-reader-mode",
+            articleURL: "https://example.com/articles/feed-reader-mode",
+            canonicalURL: "https://example.com/articles/feed-reader-mode/canonical"
+        )
+        try harness.dependencies.appSettingsRepository?.update(
+            AppSettingsUpdate(articleOpeningMode: .feedReader)
+        )
+
+        harness.dependencies.appActions.selectArticle(id: article.id, using: appState)
+
+        #expect(appState.selectedArticleID == article.id)
+        #expect(appState.selectedDetailRoute == .article(article.id))
+        #expect(appState.presentedSafariRoute == nil)
+    }
+
+    @Test
+    func readerOpeningModeSafariViewPresentsSafariAndDismissalRestoresReaderArticle() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appState = AppState()
+        let article = try insertArticle(
+            into: harness,
+            feedURL: "https://example.com/safari-mode.xml",
+            externalID: "safari-mode",
+            articleURL: "https://example.com/articles/safari-mode",
+            canonicalURL: "https://example.com/articles/safari-mode/canonical"
+        )
+        let safariURL = URL(string: "https://example.com/articles/safari-mode/canonical")!
+        try harness.dependencies.appSettingsRepository?.update(
+            AppSettingsUpdate(articleOpeningMode: .safariView)
+        )
+
+        harness.dependencies.appActions.selectArticle(id: article.id, using: appState)
+
+        #expect(appState.selectedArticleID == article.id)
+        #expect(appState.selectedDetailRoute == .safari(ArticleSafariRoute(articleID: article.id, url: safariURL)))
+        #expect(appState.presentedSafariRoute == ArticleSafariRoute(articleID: article.id, url: safariURL))
+
+        harness.dependencies.appActions.closePresentedArticleSafari(using: appState)
+
+        #expect(appState.selectedArticleID == article.id)
+        #expect(appState.selectedDetailRoute == .article(article.id))
+        #expect(appState.presentedSafariRoute == nil)
+    }
+
+    @Test
+    func sourceArticlePolicyRoutesBetweenSafariViewAndExternalBrowser() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appState = AppState()
+        let article = try insertArticle(
+            into: harness,
+            feedURL: "https://example.com/source-routing.xml",
+            externalID: "source-routing",
+            articleURL: "https://example.com/articles/source-routing",
+            canonicalURL: "https://example.com/articles/source-routing/canonical"
+        )
+        let sourceURL = URL(string: "https://example.com/articles/source-routing/canonical")!
+        let controller = ArticleScreenController()
+        var externallyOpenedURLs: [URL] = []
+
+        await controller.load(articleID: article.id, dependencies: harness.dependencies)
+        try harness.dependencies.appSettingsRepository?.update(
+            AppSettingsUpdate(articleSourceLinkOpeningPolicy: .inAppBrowser)
+        )
+
+        controller.openSourceArticle(
+            dependencies: harness.dependencies,
+            appState: appState,
+            openExternalURL: { externallyOpenedURLs.append($0) }
+        )
+
+        #expect(appState.presentedSafariRoute == ArticleSafariRoute(articleID: article.id, url: sourceURL))
+        #expect(externallyOpenedURLs.isEmpty)
+
+        harness.dependencies.appActions.closePresentedArticleSafari(using: appState)
+        try harness.dependencies.appSettingsRepository?.update(
+            AppSettingsUpdate(articleSourceLinkOpeningPolicy: .externalBrowser)
+        )
+
+        controller.openSourceArticle(
+            dependencies: harness.dependencies,
+            appState: appState,
+            openExternalURL: { externallyOpenedURLs.append($0) }
+        )
+
+        #expect(externallyOpenedURLs == [sourceURL])
+        #expect(appState.presentedSafariRoute == nil)
+        #expect(appState.selectedDetailRoute == .article(article.id))
+    }
+
+    @Test
+    func bodyLinkPolicyRoutesBetweenSafariViewAndExternalBrowser() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let appState = AppState()
+        let article = try insertArticle(
+            into: harness,
+            feedURL: "https://example.com/body-link-routing.xml",
+            externalID: "body-link-routing",
+            articleURL: "https://example.com/articles/body-link-routing"
+        )
+        let tappedURL = URL(string: "https://example.com/guides/body-link")!
+        let controller = ArticleScreenController()
+        var externallyOpenedURLs: [URL] = []
+
+        await controller.load(articleID: article.id, dependencies: harness.dependencies)
+        try harness.dependencies.appSettingsRepository?.update(
+            AppSettingsUpdate(articleBodyLinkOpeningPolicy: .inAppBrowser)
+        )
+
+        controller.handleBodyLinkTap(
+            tappedURL,
+            dependencies: harness.dependencies,
+            appState: appState,
+            openExternalURL: { externallyOpenedURLs.append($0) }
+        )
+
+        #expect(appState.presentedSafariRoute == ArticleSafariRoute(articleID: article.id, url: tappedURL))
+        #expect(externallyOpenedURLs.isEmpty)
+
+        harness.dependencies.appActions.closePresentedArticleSafari(using: appState)
+        try harness.dependencies.appSettingsRepository?.update(
+            AppSettingsUpdate(articleBodyLinkOpeningPolicy: .externalBrowser)
+        )
+
+        controller.handleBodyLinkTap(
+            tappedURL,
+            dependencies: harness.dependencies,
+            appState: appState,
+            openExternalURL: { externallyOpenedURLs.append($0) }
+        )
+
+        #expect(externallyOpenedURLs == [tappedURL])
+        #expect(appState.presentedSafariRoute == nil)
+        #expect(appState.selectedDetailRoute == .article(article.id))
+    }
+
+    private func insertArticle(
+        into harness: TestHarness,
+        feedURL: String,
+        externalID: String,
+        articleURL: String,
+        canonicalURL: String? = nil
+    ) throws -> Article {
+        let feed = try #require(try harness.insertFeeds(urls: [feedURL]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: externalID,
+            url: articleURL,
+            title: externalID
+        )
+        article.canonicalURL = canonicalURL
+        try harness.saveModelContext()
+        return article
+    }
+}

--- a/RSSReaderTests/SourceManagement/SourceManagementAppFlowTests.swift
+++ b/RSSReaderTests/SourceManagement/SourceManagementAppFlowTests.swift
@@ -6,6 +6,198 @@ import Testing
 @MainActor
 struct SourceManagementAppFlowTests {
     @Test
+    func addFeedServicePipelinePreviewsCreatesPersistsFolderPlacementAndSchedulesInitialRefreshAtAppBoundary() async throws {
+        let feedURL = "https://example.com/app-flow-feed.xml"
+        let previewStep = ScriptedHTTPClient.Step.response(
+            statusCode: 200,
+            headers: ["Content-Type": "application/rss+xml; charset=utf-8"],
+            body: makeValidRSSFeedXML(
+                channelTitle: "App Flow Feed",
+                channelLink: "https://example.com/",
+                language: "en",
+                itemTitle: "Preview Only Article",
+                itemLink: "https://example.com/articles/preview",
+                itemGUID: "preview-only-article",
+                itemDescription: "Preview article should not be persisted before app boundary refresh",
+                pubDate: "Tue, 02 Jan 2024 10:00:00 GMT"
+            )
+        )
+        let refreshStep = ScriptedHTTPClient.Step.delayedResponse(
+            statusCode: 200,
+            headers: ["Content-Type": "application/rss+xml; charset=utf-8"],
+            body: makeValidRSSFeedXML(
+                channelTitle: "App Flow Feed",
+                channelLink: "https://example.com/",
+                language: "en",
+                itemTitle: "Persisted Refresh Article",
+                itemLink: "https://example.com/articles/refreshed",
+                itemGUID: "persisted-refresh-article",
+                itemDescription: "Refresh article should be persisted after app boundary refresh",
+                pubDate: "Tue, 02 Jan 2024 11:00:00 GMT"
+            ),
+            delayNanoseconds: 200_000_000
+        )
+        let harness = try TestHarness.make(
+            httpClient: ScriptedHTTPClient(steps: [previewStep, refreshStep])
+        )
+        let service = try #require(harness.dependencies.sourceManagementService)
+        let appState = AppState()
+        let folder = try service.createFolder(SourceManagementCreateFolderCommand(name: "Tech"))
+
+        let preview = try await service.previewFeed(urlString: feedURL)
+        let createdFeed = try service.createFeed(
+            SourceManagementCreateFeedCommand(
+                preview: preview,
+                displayTitleOverride: "My App Flow Feed",
+                folderPlacement: .folder(folder.id)
+            )
+        )
+        let persistedFeedBeforeRefresh = try #require(try harness.feedRepository.fetchFeed(id: createdFeed.id))
+        let articlesBeforeRefresh = try harness.articleRepository.fetchArticles(feedID: createdFeed.id)
+
+        #expect(preview.requestedURL == feedURL)
+        #expect(preview.resolvedFeedURL == feedURL)
+        #expect(preview.title == "App Flow Feed")
+        #expect(preview.existingFeedID == nil)
+        #expect(createdFeed.title == "My App Flow Feed")
+        #expect(createdFeed.metadataTitle == "App Flow Feed")
+        #expect(createdFeed.folderID == folder.id)
+        #expect(createdFeed.folderName == "Tech")
+        #expect(persistedFeedBeforeRefresh.url == feedURL)
+        #expect(persistedFeedBeforeRefresh.title == "App Flow Feed")
+        #expect(persistedFeedBeforeRefresh.displayTitleOverride == "My App Flow Feed")
+        #expect(persistedFeedBeforeRefresh.folder?.id == folder.id)
+        #expect(persistedFeedBeforeRefresh.lastFetchedAt == nil)
+        #expect(persistedFeedBeforeRefresh.lastSuccessfulFetchAt == nil)
+        #expect(articlesBeforeRefresh.isEmpty)
+
+        _ = await harness.dependencies.appActions.completeSourceManagementFeedSave(
+            id: createdFeed.id,
+            using: appState,
+            selectsSavedFeed: false
+        )
+
+        let persistedFeedDuringScheduledRefresh = try #require(try harness.feedRepository.fetchFeed(id: createdFeed.id))
+        let articlesDuringScheduledRefresh = try harness.articleRepository.fetchArticles(feedID: createdFeed.id)
+        #expect(persistedFeedDuringScheduledRefresh.lastFetchedAt == nil)
+        #expect(persistedFeedDuringScheduledRefresh.lastSuccessfulFetchAt == nil)
+        #expect(articlesDuringScheduledRefresh.isEmpty)
+
+        await harness.dependencies.appActions.waitForScheduledFeedSaveRefreshes()
+
+        let refreshedFeed = try #require(try harness.feedRepository.fetchFeed(id: createdFeed.id))
+        let refreshedArticles = try harness.articleRepository.fetchArticles(feedID: createdFeed.id)
+        let requests = await harness.httpClient.recordedRequests()
+
+        #expect(refreshedFeed.lastFetchedAt != nil)
+        #expect(refreshedFeed.lastSuccessfulFetchAt != nil)
+        #expect(refreshedArticles.map(\.title) == ["Persisted Refresh Article"])
+        #expect(appState.selectedSidebarSelection == nil)
+        #expect(appState.isPresentingSourceManagementScreen == false)
+        #expect(requests.map(\.url.absoluteString) == [feedURL, feedURL])
+    }
+
+    @Test
+    func addFeedServicePipelineRejectsDuplicateFeedURLAfterPreviewResolvesExistingSource() async throws {
+        let feedURL = "https://example.com/duplicate-feed.xml"
+        let firstPreviewStep = ScriptedHTTPClient.Step.response(
+            statusCode: 200,
+            headers: ["Content-Type": "application/rss+xml; charset=utf-8"],
+            body: makeValidRSSFeedXML(
+                channelTitle: "Duplicate Feed",
+                channelLink: "https://example.com/",
+                language: "en",
+                itemTitle: "First Article",
+                itemLink: "https://example.com/articles/first",
+                itemGUID: "first-article",
+                itemDescription: "First description",
+                pubDate: "Tue, 02 Jan 2024 10:00:00 GMT"
+            )
+        )
+        let duplicatePreviewStep = ScriptedHTTPClient.Step.response(
+            statusCode: 200,
+            headers: ["Content-Type": "application/rss+xml; charset=utf-8"],
+            body: makeValidRSSFeedXML(
+                channelTitle: "Duplicate Feed",
+                channelLink: "https://example.com/",
+                language: "en",
+                itemTitle: "Second Article",
+                itemLink: "https://example.com/articles/second",
+                itemGUID: "second-article",
+                itemDescription: "Second description",
+                pubDate: "Tue, 02 Jan 2024 11:00:00 GMT"
+            )
+        )
+        let harness = try TestHarness.make(
+            httpClient: ScriptedHTTPClient(steps: [firstPreviewStep, duplicatePreviewStep])
+        )
+        let service = try #require(harness.dependencies.sourceManagementService)
+
+        let firstPreview = try await service.previewFeed(urlString: feedURL)
+        let createdFeed = try service.createFeed(
+            SourceManagementCreateFeedCommand(
+                preview: firstPreview,
+                folderPlacement: .ungrouped
+            )
+        )
+        let duplicatePreview = try await service.previewFeed(urlString: feedURL)
+
+        #expect(duplicatePreview.existingFeedID == createdFeed.id)
+        #expect(throws: SourceManagementServiceError.duplicateFeed(feedURL)) {
+            _ = try service.createFeed(
+                SourceManagementCreateFeedCommand(
+                    preview: duplicatePreview,
+                    folderPlacement: .ungrouped
+                )
+            )
+        }
+        #expect(try harness.feedRepository.fetchAllFeeds().map(\.url) == [feedURL])
+    }
+
+    @Test
+    func addFeedServicePipelineRejectsDuplicateDisplayTitleWithoutPersistingNewFeed() async throws {
+        let existingFeedURL = "https://example.com/existing-title.xml"
+        let newFeedURL = "https://example.com/new-title.xml"
+        let previewStep = ScriptedHTTPClient.Step.response(
+            statusCode: 200,
+            headers: ["Content-Type": "application/rss+xml; charset=utf-8"],
+            body: makeValidRSSFeedXML(
+                channelTitle: "New Metadata Title",
+                channelLink: "https://example.com/",
+                language: "en",
+                itemTitle: "New Article",
+                itemLink: "https://example.com/articles/new",
+                itemGUID: "new-article",
+                itemDescription: "New description",
+                pubDate: "Tue, 02 Jan 2024 10:00:00 GMT"
+            )
+        )
+        let harness = try TestHarness.make(
+            httpClient: ScriptedHTTPClient(steps: [previewStep])
+        )
+        let service = try #require(harness.dependencies.sourceManagementService)
+        let existingFeed = try #require(try harness.insertFeeds(urls: [existingFeedURL]).first)
+        _ = try harness.feedRepository.updateDetails(
+            for: existingFeed.id,
+            with: FeedDetailsUpdate(displayTitleOverride: "Tech News")
+        )
+
+        let preview = try await service.previewFeed(urlString: newFeedURL)
+
+        #expect(throws: SourceManagementServiceError.duplicateFeedDisplayName("tech news")) {
+            _ = try service.createFeed(
+                SourceManagementCreateFeedCommand(
+                    preview: preview,
+                    displayTitleOverride: " tech news ",
+                    folderPlacement: .ungrouped
+                )
+            )
+        }
+        #expect(try harness.feedRepository.fetchFeed(url: newFeedURL) == nil)
+        #expect(try harness.feedRepository.fetchAllFeeds().map(\.url) == [existingFeedURL])
+    }
+
+    @Test
     func sourceManagementPresentationStateUsesSeparateModalFlowAndDoesNotResetReadingShellContext() throws {
         let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
         let appState = AppState()


### PR DESCRIPTION
## Кратко
Задача App Flow Regression Tests выполнена

Реализовано:
- [x] `Add Feed End-To-End Service Pipeline Tests`: добавить non-UI integration tests для add-feed flow через `SourceManagementFeedPreviewService` / `DefaultSourceManagementService` / repositories: preview → create feed → initial refresh scheduling boundary, duplicate feed URL / display name и folder placement;
- [x] `Refresh Pipeline Diagnostics Tests`: расширить integration tests `FeedRefreshService`: rejected entry diagnostics, parse failure diagnostics, fetch log persistence, not-modified log path и batch result aggregation без сетевых side effects;
- [x] `Reader Opening And Safari Routing Tests`: добавить app-level tests для `ArticleOpeningMode` / `ArticleBodyLinkOpeningPolicy` / `ArticleSourceLinkOpeningPolicy`: выбор между app-owned reader и `SFSafariViewController`, body link routing, source article routing и dismissal state;
- [x] `Settings Side Effects Regression Tests`: покрыть non-UI side effects `SettingsScreenController`: cache clear actions, archive purge, badge preference apply, background refresh preference update и iCloud sync preference transition без изменения unrelated settings.

## Закрывает
Closes #603 
Closes #604 
Closes #605 
Closes #606 
Closes #597 