### PR TITLE
Pre-Validation UX Polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@
 #### Pre-Validation UX Polish
 - [x] `Appearance Setting Staged Preview`: сделать `interfaceThemeMode` мгновенным preview через `AppState` / theme policy, но сохранять его в `AppSettings` только после Apply; закрытие `SettingsScreen` без Apply откатывает preview, а кнопка применения остаётся общей commit-action для staged-настроек;
 - [x] `Unread Swipe Read Retention`: при swipe `Read` в текущем `Unread` списке удерживать статью видимой и серой до следующего reload / повторного входа на экран, как чтение при открытии статьи;
-- [ ] `Context Menu Glyphs`: добавить `Label` / SF Symbols в меню фильтров (`All Items`, `Unread`, `Starred`) и long-tap меню источников/папок (`Organize...`, `Edit...`, `Delete`, `Unsubscribe`) без изменения существующих action boundaries.
+- [x] `Context Menu Glyphs`: добавить `Label` / SF Symbols в меню фильтров (`All Items`, `Unread`, `Starred`) и long-tap меню источников/папок (`Organize...`, `Edit...`, `Delete`, `Unsubscribe`) без изменения существующих action boundaries.
 
 #### Source Portability
 - [ ] `OPML Import Contract`: определить поддерживаемый формат импорта (`OPML` 1.0 / 2.0), mapping nested `outline` в folders, duplicate policy, URL normalization и формат ошибок для invalid sources;

--- a/README.md
+++ b/README.md
@@ -569,10 +569,7 @@
 
 ### Pre-Validation Product Readiness
 #### Pre-Validation UX Polish
-- [ ] `Settings Live Apply Policy Audit`: разделить настройки на `live-applied`, `staged until Apply` и `requires relaunch`, чтобы `Settings Screen` явно различал мгновенные UI side effects, отложенное сохранение и настройки, которые не могут примениться в текущем runtime;
-- [ ] `Appearance Setting Live Apply`: сделать `interfaceThemeMode` мгновенно применяемым при выборе в `SettingsScreen`, без ожидания кнопки применения, с сохранением через `AppSettingsService` и обновлением `AppState` / theme policy;
-- [ ] `Settings Apply Button Scope`: после live-apply определить, остаётся ли кнопка применения общей commit-action для всех staged-настроек или должна показываться/активироваться только для настроек, которым действительно нужен отложенный apply;
-- [ ] `Settings Live Apply Regression Tests`: покрыть сценарии, где тема применяется сразу, persisted snapshot обновляется, `canApplyChanges` не остаётся включённым после live-only изменения, а sync/relaunch-настройки не начинают притворяться мгновенно применёнными;
+- [x] `Appearance Setting Staged Preview`: сделать `interfaceThemeMode` мгновенным preview через `AppState` / theme policy, но сохранять его в `AppSettings` только после Apply; закрытие `SettingsScreen` без Apply откатывает preview, а кнопка применения остаётся общей commit-action для staged-настроек;
 - [ ] `Context Menu Glyph Audit`: пройтись по `Menu` / `contextMenu` в `SettingsScreen`, `SidebarRows`, article actions и source management, определить единый icon policy для обычных, destructive и selected actions;
 - [ ] `Sidebar Context Menu Glyphs`: если audit подтверждает пользу глифов, оформить long-tap меню источников и папок через `Label` / SF Symbols для действий organize, edit, unsubscribe и delete без изменения существующих action boundaries.
 

--- a/README.md
+++ b/README.md
@@ -570,8 +570,8 @@
 ### Pre-Validation Product Readiness
 #### Pre-Validation UX Polish
 - [x] `Appearance Setting Staged Preview`: сделать `interfaceThemeMode` мгновенным preview через `AppState` / theme policy, но сохранять его в `AppSettings` только после Apply; закрытие `SettingsScreen` без Apply откатывает preview, а кнопка применения остаётся общей commit-action для staged-настроек;
-- [ ] `Context Menu Glyph Audit`: пройтись по `Menu` / `contextMenu` в `SettingsScreen`, `SidebarRows`, article actions и source management, определить единый icon policy для обычных, destructive и selected actions;
-- [ ] `Sidebar Context Menu Glyphs`: если audit подтверждает пользу глифов, оформить long-tap меню источников и папок через `Label` / SF Symbols для действий organize, edit, unsubscribe и delete без изменения существующих action boundaries.
+- [x] `Unread Swipe Read Retention`: при swipe `Read` в текущем `Unread` списке удерживать статью видимой и серой до следующего reload / повторного входа на экран, как чтение при открытии статьи;
+- [ ] `Context Menu Glyphs`: добавить `Label` / SF Symbols в меню фильтров (`All Items`, `Unread`, `Starred`) и long-tap меню источников/папок (`Organize...`, `Edit...`, `Delete`, `Unsubscribe`) без изменения существующих action boundaries.
 
 #### Source Portability
 - [ ] `OPML Import Contract`: определить поддерживаемый формат импорта (`OPML` 1.0 / 2.0), mapping nested `outline` в folders, duplicate policy, URL normalization и формат ошибок для invalid sources;

--- a/RSSReader/Views/ArticlesScreen/ArticleListSession.swift
+++ b/RSSReader/Views/ArticlesScreen/ArticleListSession.swift
@@ -52,9 +52,14 @@ struct ArticleListSession: Equatable {
         self.entries = entries
     }
 
-    mutating func updateArticle(_ article: ArticleListItemDTO) {
+    mutating func updateArticle(
+        _ article: ArticleListItemDTO,
+        membershipStatus: ArticleListEntryMembershipStatus? = nil
+    ) {
         entries = entries.map { entry in
-            entry.id == article.id ? entry.updating(article: article) : entry
+            entry.id == article.id
+                ? entry.updating(article: article, membershipStatus: membershipStatus)
+                : entry
         }
     }
 
@@ -159,10 +164,13 @@ struct ArticleListEntry: Identifiable, Equatable {
         self.membershipStatus = membershipStatus
     }
 
-    func updating(article: ArticleListItemDTO) -> ArticleListEntry {
+    func updating(
+        article: ArticleListItemDTO,
+        membershipStatus: ArticleListEntryMembershipStatus? = nil
+    ) -> ArticleListEntry {
         ArticleListEntry(
             article: article,
-            membershipStatus: membershipStatus
+            membershipStatus: membershipStatus ?? self.membershipStatus
         )
     }
 

--- a/RSSReader/Views/ArticlesScreen/ArticlesScreenMutationReducer.swift
+++ b/RSSReader/Views/ArticlesScreen/ArticlesScreenMutationReducer.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum ArticleRowMutation: Equatable {
-    case update(ArticleListItemDTO)
+    case update(ArticleListItemDTO, membershipStatus: ArticleListEntryMembershipStatus? = nil)
     case remove
 }
 
@@ -48,17 +48,19 @@ enum ArticlesScreenMutationReducer {
         filter: ArticleListFilter
     ) -> ArticleRowMutation {
         let updatedIsRead = article.isRead == false
+        let updatedArticle = article.updating(
+            isRead: updatedIsRead,
+            isStarred: article.isStarred
+        )
 
         if filter == .unread && updatedIsRead {
-            return .remove
+            return .update(
+                updatedArticle,
+                membershipStatus: .retainedAfterRead
+            )
         }
 
-        return .update(
-            article.updating(
-                isRead: updatedIsRead,
-                isStarred: article.isStarred
-            )
-        )
+        return .update(updatedArticle)
     }
 
     static func mutationAfterToggleStarred(
@@ -85,7 +87,7 @@ enum ArticlesScreenMutationReducer {
         allArticles: [ArticleListItemDTO]
     ) -> [ArticleListItemDTO] {
         switch mutation {
-        case .update(let updatedArticle):
+        case .update(let updatedArticle, _):
             allArticles.map { article in
                 article.id == articleID ? updatedArticle : article
             }

--- a/RSSReader/Views/ArticlesScreen/ArticlesScreenState.swift
+++ b/RSSReader/Views/ArticlesScreen/ArticlesScreenState.swift
@@ -236,8 +236,11 @@ struct ArticlesScreenState {
         navigationSubtitle: String
     ) {
         switch mutation {
-        case .update(let updatedArticle):
-            articleListSession.updateArticle(updatedArticle)
+        case .update(let updatedArticle, let membershipStatus):
+            articleListSession.updateArticle(
+                updatedArticle,
+                membershipStatus: membershipStatus
+            )
         case .remove:
             articleListSession.removeArticle(id: articleID)
         }

--- a/RSSReader/Views/SettingsScreen/SettingsScreenController+Appearance.swift
+++ b/RSSReader/Views/SettingsScreen/SettingsScreenController+Appearance.swift
@@ -19,5 +19,14 @@ extension SettingsScreenController {
         var input = screenState.settingsInput
         input.interfaceThemeMode = selectedMode
         screenState.applyDraftInput(input)
+        appState?.applyInterfaceThemeMode(selectedMode)
+    }
+
+    func discardPreviewedAppearanceChanges(appState: AppState?) {
+        guard screenState.settingsInput.interfaceThemeMode != screenState.settingsSnapshot.interfaceThemeMode else {
+            return
+        }
+
+        appState?.applyInterfaceThemeMode(screenState.settingsSnapshot.interfaceThemeMode)
     }
 }

--- a/RSSReader/Views/SettingsScreen/SettingsScreenView.swift
+++ b/RSSReader/Views/SettingsScreen/SettingsScreenView.swift
@@ -14,6 +14,7 @@ struct SettingsScreenView: View {
     @Environment(\.appThemeVariant) private var appThemeVariant
     @Environment(AppState.self) private var appState
     @State private var controller: SettingsScreenController
+    @State private var didCommitSettingsChanges = false
     @State private var isArchivedArticlesPurgeConfirmationPresented = false
     @State private var isArticleImageCacheResetConfirmationPresented = false
     @State private var isSourceIconCacheResetConfirmationPresented = false
@@ -60,6 +61,10 @@ struct SettingsScreenView: View {
                     await controller.refreshArticleImageCacheAvailability(dependencies: dependencies)
                     await controller.refreshSourceIconCacheAvailability(dependencies: dependencies)
                 }
+                .onDisappear {
+                    guard didCommitSettingsChanges == false else { return }
+                    controller.discardPreviewedAppearanceChanges(appState: appState)
+                }
                 .alert(
                     "Clear archived articles?",
                     isPresented: $isArchivedArticlesPurgeConfirmationPresented
@@ -105,6 +110,7 @@ struct SettingsScreenView: View {
                     appState: appState
                 )
                 if didApplyChanges {
+                    didCommitSettingsChanges = true
                     dismiss()
                 }
             },

--- a/RSSReader/Views/Sidebar/SidebarRows.swift
+++ b/RSSReader/Views/Sidebar/SidebarRows.swift
@@ -43,16 +43,22 @@ struct SidebarFeedRowView: View {
             selection = row.selection
         }
         .contextMenu {
-            Button("Organize...") {
+            Button {
                 actionHandlers.showFeedOrganizer(row.id)
+            } label: {
+                Label("Organize...", systemImage: "folder")
             }
 
-            Button("Edit...") {
+            Button {
                 actionHandlers.showFeedEditor(row.id)
+            } label: {
+                Label("Edit...", systemImage: "pencil")
             }
 
-            Button("Unsubscribe", role: .destructive) {
+            Button(role: .destructive) {
                 actionHandlers.unsubscribeFeed(row.id)
+            } label: {
+                Label("Unsubscribe", systemImage: "minus.circle")
             }
         }
         .listRowSeparator(.hidden)
@@ -96,12 +102,16 @@ struct SidebarFolderRowView: View {
         }
         .font(.body)
         .contextMenu {
-            Button("Edit...") {
+            Button {
                 actionHandlers.showFolderEditor(row.name)
+            } label: {
+                Label("Edit...", systemImage: "pencil")
             }
 
-            Button("Delete", role: .destructive) {
+            Button(role: .destructive) {
                 actionHandlers.deleteFolder(row.name)
+            } label: {
+                Label("Delete", systemImage: "trash")
             }
         }
         .listRowSeparator(.hidden)

--- a/RSSReader/Views/Sidebar/SidebarToolbarContent.swift
+++ b/RSSReader/Views/Sidebar/SidebarToolbarContent.swift
@@ -50,9 +50,9 @@ private struct SidebarSourcesFilterMenu: View {
 
     var body: some View {
         Menu {
-            sourcesFilterButton("All Items", filter: .allItems)
-            sourcesFilterButton("Unread", filter: .unread)
-            sourcesFilterButton("Starred", filter: .starred)
+            sourcesFilterButton("All Items", systemImage: "tray.full", filter: .allItems)
+            sourcesFilterButton("Unread", systemImage: "circle", filter: .unread)
+            sourcesFilterButton("Starred", systemImage: "star", filter: .starred)
         } label: {
             Image(systemName: "line.3.horizontal.decrease")
         }
@@ -60,14 +60,23 @@ private struct SidebarSourcesFilterMenu: View {
     }
 
     @ViewBuilder
-    private func sourcesFilterButton(_ title: String, filter: SourcesFilter) -> some View {
+    private func sourcesFilterButton(
+        _ title: String,
+        systemImage: String,
+        filter: SourcesFilter
+    ) -> some View {
         Button {
             actionHandlers.applySourcesFilter(filter)
         } label: {
-            if selectedSourcesFilter == filter {
-                Label(title, systemImage: "checkmark")
-            } else {
-                Text(title)
+            Label {
+                HStack {
+                    Text(title)
+                    if selectedSourcesFilter == filter {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            } icon: {
+                Image(systemName: systemImage)
             }
         }
     }

--- a/RSSReaderTests/ArticlesScreen/ArticlesScreenControllerSessionReloadTests.swift
+++ b/RSSReaderTests/ArticlesScreen/ArticlesScreenControllerSessionReloadTests.swift
@@ -7,6 +7,49 @@ import Testing
 @MainActor
 struct ArticlesScreenControllerSessionReloadTests {
     @Test
+    func articlesScreenControllerRetainsUnreadArticleAfterManualReadToggleInCurrentSession() async throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let feed = try #require(try harness.insertFeeds(urls: ["https://example.com/manual-read-retention.xml"]).first)
+        let article = try harness.insertArticle(
+            feed: feed,
+            externalID: "manual-read-retention-article",
+            url: "https://example.com/articles/manual-read-retention",
+            title: "Manual Read Retention"
+        )
+        let controller = ArticlesScreenController()
+
+        await controller.load(
+            selection: .feed(feed.id),
+            sourcesFilter: .unread,
+            dependencies: harness.dependencies
+        )
+
+        let loadedArticle = try #require(controller.screenState.articles.first)
+        controller.toggleArticleReadStatus(
+            loadedArticle,
+            selection: .feed(feed.id),
+            sourcesFilter: .unread,
+            dependencies: harness.dependencies,
+            isPreviewMode: false
+        )
+
+        let persistedState = try #require(
+            try harness.articleStateRepository.fetchState(
+                feedID: feed.id,
+                articleExternalID: article.externalID
+            )
+        )
+
+        #expect(persistedState.isRead)
+        #expect(controller.screenState.phase == .loaded)
+        #expect(controller.screenState.articles.map(\.id) == [article.id])
+        #expect(controller.screenState.articles.first?.isRead == true)
+        #expect(controller.screenState.articleListSession.entries.map(\.membershipStatus) == [.retainedAfterRead])
+        #expect(controller.screenState.navigationSubtitle == "No Unread Items")
+        #expect(controller.screenState.toolbarActions.isMarkAllAsReadEnabled == false)
+    }
+
+    @Test
     func articlesScreenControllerRetainsSessionReadArticleOnlyForRetainingReloads() async throws {
         let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
         let articleStateService = try #require(harness.dependencies.articleStateService)

--- a/RSSReaderTests/ArticlesScreen/ArticlesScreenMutationReducerTests.swift
+++ b/RSSReaderTests/ArticlesScreen/ArticlesScreenMutationReducerTests.swift
@@ -20,7 +20,7 @@ struct ArticlesScreenMutationReducerTests {
     }
 
     @Test
-    func articlesScreenMutationReducerProducesRemoveMutationWhenReadToggleHappensInUnreadFilter() {
+    func articlesScreenMutationReducerRetainsArticleWhenReadToggleHappensInUnreadFilter() {
         let unreadArticle = makeArticleListItemDTO(isRead: false, isStarred: false)
 
         let mutation = ArticlesScreenMutationReducer.mutationAfterToggleReadStatus(
@@ -28,7 +28,19 @@ struct ArticlesScreenMutationReducerTests {
             filter: ArticleListFilter.unread
         )
 
-        #expect(mutation == .remove)
+        let updatedArticle: ArticleListItemDTO?
+        let membershipStatus: ArticleListEntryMembershipStatus?
+        if case .update(let article, let status) = mutation {
+            updatedArticle = article
+            membershipStatus = status
+        } else {
+            updatedArticle = nil
+            membershipStatus = nil
+        }
+
+        #expect(updatedArticle?.isRead == true)
+        #expect(updatedArticle?.isStarred == false)
+        #expect(membershipStatus == .retainedAfterRead)
     }
 
     @Test
@@ -41,7 +53,7 @@ struct ArticlesScreenMutationReducerTests {
         )
 
         let updatedArticle: ArticleListItemDTO?
-        if case .update(let article) = mutation {
+        if case .update(let article, _) = mutation {
             updatedArticle = article
         } else {
             updatedArticle = nil

--- a/RSSReaderTests/ArticlesScreen/ArticlesScreenStateMutationTests.swift
+++ b/RSSReaderTests/ArticlesScreen/ArticlesScreenStateMutationTests.swift
@@ -119,9 +119,16 @@ struct ArticlesScreenStateMutationTests {
     }
 
     @Test
-    func articlesScreenStateRemovesArticleRowForReadActionInUnreadSelection() {
+    func articlesScreenStateRetainsArticleRowForReadActionInUnreadSelection() {
         var state = ArticlesScreenState()
         let unreadItem = makeArticleListItemDTO(isRead: false, isStarred: false)
+        let updatedItem = makeArticleListItemDTO(
+            id: unreadItem.id,
+            feedID: unreadItem.feedID,
+            articleExternalID: unreadItem.articleExternalID,
+            isRead: true,
+            isStarred: false
+        )
 
         state.applyLoadedArticles(
             [unreadItem],
@@ -131,13 +138,19 @@ struct ArticlesScreenStateMutationTests {
         )
         state.applyArticleRowMutation(
             articleID: unreadItem.id,
-            mutation: .remove,
-            navigationSubtitle: "0 Unread Items"
+            mutation: .update(
+                updatedItem,
+                membershipStatus: .retainedAfterRead
+            ),
+            navigationSubtitle: "No Unread Items"
         )
 
-        #expect(state.phase == .empty)
-        #expect(state.navigationSubtitle == "0 Unread Items")
-        #expect(state.articles.isEmpty)
+        #expect(state.phase == .loaded)
+        #expect(state.navigationSubtitle == "No Unread Items")
+        #expect(state.articles.map(\.id) == [unreadItem.id])
+        #expect(state.articles.first?.isRead == true)
+        #expect(state.articleListSession.entries.map(\.membershipStatus) == [.retainedAfterRead])
+        #expect(state.toolbarActions.isMarkAllAsReadEnabled == false)
     }
 
     @Test

--- a/RSSReaderTests/Settings/SettingsScreenControllerPersistenceTests.swift
+++ b/RSSReaderTests/Settings/SettingsScreenControllerPersistenceTests.swift
@@ -183,11 +183,65 @@ struct SettingsScreenControllerPersistenceTests {
             appState: appState
         )
 
-        #expect(appState.interfaceThemeMode == .automaticLightDark)
+        let settingsBeforeApply = try repository.fetchOrCreate()
+        #expect(appState.interfaceThemeMode == .black)
+        #expect(settingsBeforeApply.interfaceThemeMode == .automaticLightDark)
+        #expect(controller.viewState().canApplyChanges)
         #expect(controller.applySettingsChanges(dependencies: harness.dependencies, appState: appState))
         let persistedSettings = try repository.fetchOrCreate()
         #expect(controller.screenState.settingsSnapshot.interfaceThemeMode == .black)
         #expect(persistedSettings.interfaceThemeMode == .black)
         #expect(appState.interfaceThemeMode == .black)
+    }
+
+    @Test
+    func settingsScreenControllerRollsBackPreviewedInterfaceThemeModeWithoutPersistingChanges() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let repository = try #require(harness.dependencies.appSettingsRepository)
+        let controller = SettingsScreenController()
+        let appState = AppState()
+
+        controller.loadSettings(dependencies: harness.dependencies, appState: appState)
+        controller.handlePickerOptionSelection(
+            itemID: .appearance,
+            optionID: InterfaceThemeMode.dark.rawValue,
+            dependencies: harness.dependencies,
+            appState: appState
+        )
+
+        #expect(appState.interfaceThemeMode == .dark)
+        #expect(controller.viewState().canApplyChanges)
+
+        controller.discardPreviewedAppearanceChanges(appState: appState)
+
+        let persistedSettings = try repository.fetchOrCreate()
+        #expect(appState.interfaceThemeMode == .automaticLightDark)
+        #expect(persistedSettings.interfaceThemeMode == .automaticLightDark)
+        #expect(controller.screenState.settingsSnapshot.interfaceThemeMode == .automaticLightDark)
+        #expect(controller.screenState.settingsInput.interfaceThemeMode == .dark)
+    }
+
+    @Test
+    func settingsScreenControllerKeepsApplyDisabledWhenPreviewedThemeReturnsToOriginalValue() throws {
+        let harness = try TestHarness.make(httpClient: ScriptedHTTPClient())
+        let controller = SettingsScreenController()
+        let appState = AppState()
+
+        controller.loadSettings(dependencies: harness.dependencies, appState: appState)
+        controller.handlePickerOptionSelection(
+            itemID: .appearance,
+            optionID: InterfaceThemeMode.dark.rawValue,
+            dependencies: harness.dependencies,
+            appState: appState
+        )
+        controller.handlePickerOptionSelection(
+            itemID: .appearance,
+            optionID: InterfaceThemeMode.automaticLightDark.rawValue,
+            dependencies: harness.dependencies,
+            appState: appState
+        )
+
+        #expect(appState.interfaceThemeMode == .automaticLightDark)
+        #expect(controller.viewState().canApplyChanges == false)
     }
 }


### PR DESCRIPTION
## Кратко
Реализовано:
- [x] `Appearance Setting Staged Preview`: сделать `interfaceThemeMode` мгновенным preview через `AppState` / theme policy, но сохранять его в `AppSettings` только после Apply; закрытие `SettingsScreen` без Apply откатывает preview, а кнопка применения остаётся общей commit-action для staged-настроек;
- [x] `Unread Swipe Read Retention`: при swipe `Read` в текущем `Unread` списке удерживать статью видимой и серой до следующего reload / повторного входа на экран, как чтение при открытии статьи;
- [x] `Context Menu Glyphs`: добавить `Label` / SF Symbols в меню фильтров (`All Items`, `Unread`, `Starred`) и long-tap меню источников/папок (`Organize...`, `Edit...`, `Delete`, `Unsubscribe`) без изменения существующих action boundaries.

## Закрывает
Closes #612 
Closes #616 
Closes #617 
Closes #611 